### PR TITLE
Fix exception thrown when tye run is shutting down

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v1
       
     - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v1.0.0
+      uses: actions/setup-dotnet@v1
       with:
         version: 3.1.100
      

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v1
       
     - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v1.0.0
+      uses: actions/setup-dotnet@v1
       with:
         version: 3.1.100
      

--- a/src/micronetes/Micronetes.Hosting.Diagnostics/DiagnosticsCollector.cs
+++ b/src/micronetes/Micronetes.Hosting.Diagnostics/DiagnosticsCollector.cs
@@ -236,6 +236,7 @@ namespace Micronetes.Hosting.Diagnostics
                     {
                     }
                     // If the process has already exited, a ServerNotAvailableException will be thrown.
+                    // This can always race with tye shutting down and a process being restarted on exiting.
                     catch (ServerNotAvailableException)
                     {
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/tye/issues/12

There is a race when tye run is shutting down and the EventPipe tries to restart the event pipe.

The specific race is that on tye shutdown, a cancellation token will eventually be fired
https://github.com/dotnet/tye/blob/939819741054a63a9da4062a16b3866c3994ccde/src/micronetes/Micronetes.Hosting/EventPipeDiagnosticsRunner.cs#L91

However, inside of the DiagnosticsCollector, it will continue to retry starting the event pipe until the cancellationToken is canceled or there is a fatal exception. 

https://github.com/dotnet/tye/blob/939819741054a63a9da4062a16b3866c3994ccde/src/micronetes/Micronetes.Hosting.Diagnostics/DiagnosticsCollector.cs#L187

After the process exits which the EventPipe is listening on, it will try to restart the event pipe, however the process has already exited. Calling StartEventPipeSession and Stop will both fail.

For now, I'm just going to catch ServerNotAvailableException from both places. I honestly think there are other gaps here with correctly restarting the event pipe here. I'll file a follow up issue.