### PR TITLE
Use full paths to project files

### DIFF
--- a/src/Tye.Core/ProjectReader.cs
+++ b/src/Tye.Core/ProjectReader.cs
@@ -68,10 +68,12 @@ namespace Tye
                 }
 
                 output.WriteDebugLine("Running 'dotnet msbuild'.");
-                output.WriteCommandLine("dotnet", $"msbuild {restore} /t:EvaluateTyeProjectInfo \"/p:TyeTargetLocation={programRoot}\" \"/p:TyeOutputFilePath={outputFilePath}\"");
+                var msbuildCommand = $"msbuild {restore} /t:EvaluateTyeProjectInfo \"/p:TyeTargetLocation={programRoot}\" \"/p:TyeOutputFilePath={outputFilePath}\"";
+
+                output.WriteCommandLine("dotnet", msbuildCommand);
                 var exitCode = await Process.ExecuteAsync(
                     $"dotnet",
-                    $"msbuild {restore} /t:EvaluateTyeProjectInfo \"/p:TyeTargetLocation={programRoot}\" \"/p:TyeOutputFilePath={outputFilePath}\"",
+                    msbuildCommand,
                     workingDir: projectFile.DirectoryName,
                     stdOut: capture.StdOut,
                     stdErr: capture.StdErr);

--- a/src/tye/Program.DeployCommand.cs
+++ b/src/tye/Program.DeployCommand.cs
@@ -70,7 +70,8 @@ namespace Tye
             {
                 if (configService.Project is string projectFile)
                 {
-                    var project = new Project(projectFile);
+                    var fullPathProjectFile = Path.Combine(application.Source.DirectoryName, projectFile);
+                    var project = new Project(fullPathProjectFile);
                     var service = new Service(configService.Name)
                     {
                         Source = project,
@@ -89,7 +90,7 @@ namespace Tye
 
                     var serviceEntry = new ServiceEntry(service, configService.Name);
 
-                    await ProjectReader.ReadProjectDetailsAsync(output, new FileInfo(projectFile), project);
+                    await ProjectReader.ReadProjectDetailsAsync(output, new FileInfo(fullPathProjectFile), project);
 
                     var container = new ContainerInfo()
                     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/tye/issues/64

Something I noticed when doing local testing. The tye deploy command was relying on being run in the same directory as tye.yaml or equivalent file.