### PR TITLE
Add replicas to service

### DIFF
--- a/src/Tye.Core/KubernetesManifestGenerator.cs
+++ b/src/Tye.Core/KubernetesManifestGenerator.cs
@@ -108,6 +108,8 @@ namespace Tye
             var spec = new YamlMappingNode();
             root.Add("spec", spec);
 
+            spec.Add("replicas", service.Service.Replicas.ToString());
+
             var selector = new YamlMappingNode();
             spec.Add("selector", selector);
 

--- a/src/Tye.Core/Service.cs
+++ b/src/Tye.Core/Service.cs
@@ -26,5 +26,7 @@ namespace Tye
         // Represents bindings *published* by this service
         // See GeneratedAssets for bindings consumed by the service
         public List<ServiceBinding> Bindings { get; } = new List<ServiceBinding>();
+
+        public int Replicas { get; set; }
     }
 }

--- a/src/tye/Program.DeployCommand.cs
+++ b/src/tye/Program.DeployCommand.cs
@@ -77,6 +77,8 @@ namespace Tye
                         Source = project,
                     };
 
+                    service.Replicas = configService.Replicas ?? 1;
+
                     foreach (var configBinding in configService.Bindings)
                     {
                         service.Bindings.Add(new ServiceBinding(configBinding.Name ?? service.Name)


### PR DESCRIPTION
Fixes https://github.com/dotnet/tye/issues/45

@rynowak currently this always will add the replica mapping in the yaml file, even if there is only one replica. I think that's fine, but something to call out.