### PR TITLE
Dispose webapp on StopAsync

### DIFF
--- a/src/Tye.Hosting/TyeHost.cs
+++ b/src/Tye.Hosting/TyeHost.cs
@@ -29,7 +29,7 @@ namespace Tye.Hosting
             _args = args;
         }
 
-        public WebApplication? WebApplication { get; set; }
+        public WebApplication? DashboardWebApplication { get; set; }
 
         public async Task RunAsync()
         {
@@ -45,7 +45,7 @@ namespace Tye.Hosting
         public async Task<WebApplication> StartAsync()
         {
             var app = BuildWebApplication(_application, _args);
-            WebApplication = app;
+            DashboardWebApplication = app;
 
             ConfigureApplication(app);
 
@@ -85,11 +85,11 @@ namespace Tye.Hosting
             }
             finally
             {
-                if (WebApplication != null)
+                if (DashboardWebApplication != null)
                 {
                     // Stop the host after everything else has been shutdown
-                    await WebApplication.StopAsync();
-                    WebApplication.Dispose();
+                    await DashboardWebApplication.StopAsync();
+                    DashboardWebApplication.Dispose();
                 }
             }
         }

--- a/test/E2ETest/TyeRunTest.cs
+++ b/test/E2ETest/TyeRunTest.cs
@@ -30,7 +30,7 @@ namespace E2ETest
 
                 // Make sure dashboard and applications are up.
                 // Dashboard should be hosted in same process.
-                var dashboardResponse = await client.GetStringAsync(new Uri(host.WebApplication!.Addresses.First()));
+                var dashboardResponse = await client.GetStringAsync(new Uri(host.DashboardWebApplication!.Addresses.First()));
 
                 // Only one service for single application.
                 var service = application.Services.First();


### PR DESCRIPTION
Using statements are sneaky...

Fixes https://github.com/dotnet/tye/issues/69.

I also made it so the WebApplication is a property rather than returned from StartAsync.