### PR TITLE
Append port to service port name

### DIFF
--- a/src/tye/Program.DeployCommand.cs
+++ b/src/tye/Program.DeployCommand.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Tye.ConfigModel;
@@ -79,8 +80,24 @@ namespace Tye
 
                     service.Replicas = configService.Replicas ?? 1;
 
-                    foreach (var configBinding in configService.Bindings)
+                    if (configService.Bindings.Count > 1)
                     {
+                        // If there are more than one binding, append the port by default
+                        // to make sure there are no name conflicts.
+                        foreach (var configBinding in configService.Bindings)
+                        {
+                            service.Bindings.Add(new ServiceBinding(configBinding.Name ?? $"{service.Name}-{configBinding.Port}")
+                            {
+                                ConnectionString = configBinding.ConnectionString,
+                                Host = configBinding.Host,
+                                Port = configBinding.Port,
+                                Protocol = configBinding.Protocol,
+                            });
+                        }
+                    }
+                    else
+                    {
+                        var configBinding = configService.Bindings.First();
                         service.Bindings.Add(new ServiceBinding(configBinding.Name ?? service.Name)
                         {
                             ConnectionString = configBinding.ConnectionString,


### PR DESCRIPTION
Fixes https://github.com/dotnet/tye/issues/42. I was getting really fed up with it so I cranked it out.

This fix assumes that a specific binding will have a port associated with it. 