### PR TITLE
Fix a few issues with test

### DIFF
--- a/src/Tye.Hosting/ProcessRunner.cs
+++ b/src/Tye.Hosting/ProcessRunner.cs
@@ -276,7 +276,7 @@ namespace Tye.Hosting
         {
             // TODO: Use msbuild to get the target path
 
-            var outputFileName = Path.GetFileNameWithoutExtension(projectFilePath) + (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "");
+            var outputFileName = Path.GetFileNameWithoutExtension(projectFilePath) + (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : ".dll");
 
             var debugOutputPath = Path.Combine(Path.GetDirectoryName(projectFilePath)!, "bin", "Debug");
 

--- a/src/Tye.Hosting/Tye.Hosting.csproj
+++ b/src/Tye.Hosting/Tye.Hosting.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Sln" Version="0.3.0" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.7.0" />
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>

--- a/test/E2ETest/E2ETest.csproj
+++ b/test/E2ETest/E2ETest.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\src\tye\TempDirectory.cs" Link="TempDirectory.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/test/E2ETest/TyeRunTest.cs
+++ b/test/E2ETest/TyeRunTest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Tye;
 using Tye.ConfigModel;
 using Tye.Hosting;
 using Xunit;
@@ -15,8 +16,14 @@ namespace E2ETest
         [Fact]
         public async Task SingleProjectTest()
         {
-            var application = ConfigFactory.FromFile(new FileInfo(Path.Combine(GetSolutionRootDirectory("tye"), "samples", "single-project", "test-project", "test-project.csproj")));
-            var host = new TyeHost(application.ToHostingApplication(), new string[0]);
+            var projectDirectory = new DirectoryInfo(Path.Combine(GetSolutionRootDirectory("tye"), "samples", "single-project", "test-project"));
+            using var tempDirectory = TempDirectory.Create();
+            DirectoryCopy.Copy(projectDirectory.FullName, tempDirectory.DirectoryPath);
+
+            var projectFile = new FileInfo(Path.Combine(tempDirectory.DirectoryPath, "test-project.csproj"));
+
+            var application = ConfigFactory.FromFile(projectFile);
+            var host = new TyeHost(application.ToHostingApplication(), Array.Empty<string>());
             await host.StartAsync();
             try
             {


### PR DESCRIPTION
- With 3.1.102 I need to list pipelines explicitly
- Copy test assets to a temp directory (arcade needs it)
- Use .dll on *nix instead of the executable. I'm not seeing the
  the executable created on macos. Older versions of tye successful
  use the .dll.