### PR TITLE
Tye run can fail to stop and hang

### DIFF
--- a/src/Tye.Hosting/TyeHost.cs
+++ b/src/Tye.Hosting/TyeHost.cs
@@ -5,22 +5,22 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Tye.Hosting.Diagnostics;
-using Tye.Hosting.Model;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Serilog;
-using Serilog.Filters;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Hosting;
 using Serilog.Core;
 using Serilog.Events;
+using Serilog.Filters;
+using Tye.Hosting.Diagnostics;
+using Tye.Hosting.Model;
 
 namespace Tye.Hosting
 {
-    public class TyeHost
+    public class TyeHost : IDisposable
     {
         private Microsoft.Extensions.Logging.ILogger? _logger;
         private IHostApplicationLifetime? _lifetime;
@@ -98,7 +98,6 @@ namespace Tye.Hosting
                 {
                     // Stop the host after everything else has been shutdown
                     await DashboardWebApplication.StopAsync();
-                    DashboardWebApplication.Dispose();
                 }
             }
         }
@@ -180,6 +179,11 @@ namespace Tye.Hosting
                 new ProcessRunner(logger, ProcessRunnerOptions.FromArgs(args)),
             });
             return processor;
+        }
+
+        public void Dispose()
+        {
+            DashboardWebApplication?.Dispose();
         }
     }
 }

--- a/src/tye/Program.RunCommand.cs
+++ b/src/tye/Program.RunCommand.cs
@@ -55,7 +55,7 @@ namespace Tye
                 Required = false
             });
 
-            command.Handler = CommandHandler.Create<IConsole, FileInfo>((console, path) =>
+            command.Handler = CommandHandler.Create<IConsole, FileInfo>(async (console, path) =>
             {
                 // Workaround for https://github.com/dotnet/command-line-api/issues/723#issuecomment-593062654
                 if (path is null)
@@ -68,8 +68,8 @@ namespace Tye
 
                 InitializeThreadPoolSettings(serviceCount);
 
-                var host = new TyeHost(application.ToHostingApplication(), args);
-                return host.RunAsync();
+                using var host = new TyeHost(application.ToHostingApplication(), args);
+                await host.RunAsync();
             });
 
             return command;

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -37,7 +37,7 @@ namespace E2ETest
             var projectFile = new FileInfo(Path.Combine(tempDirectory.DirectoryPath, "test-project.csproj"));
 
             var application = ConfigFactory.FromFile(projectFile);
-            var host = new TyeHost(application.ToHostingApplication(), Array.Empty<string>())
+            using var host = new TyeHost(application.ToHostingApplication(), Array.Empty<string>())
             {
                 Sink = sink,
             };


### PR DESCRIPTION
- Make TyeHost disposable and dispose it from the outside so that exceptions don't stop it from shutting down.