### PR TITLE
Catch IOException in the proxy

### DIFF
--- a/src/Tye.Hosting/ProxyService.cs
+++ b/src/Tye.Hosting/ProxyService.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Net;
@@ -11,13 +12,11 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Bedrock.Framework;
-using Tye.Hosting.Model;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using System.IO;
 
 namespace Tye.Hosting
 {


### PR DESCRIPTION
Avoding this error on shutdown:

```
[23:34:07 DBG] Proxy error for service streamr
System.IO.IOException: Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host..
 ---> System.Net.Sockets.SocketException (10054): An existing connection was forcibly closed by the remote host.
   --- End of inner exception stack trace ---
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.GetResult(Int16 token)
   at System.IO.Pipelines.PipeWriter.CopyFromAsync(Stream source, CancellationToken cancellationToken)
   at Tye.Hosting.ProxyService.<>c__DisplayClass3_4.<<StartAsync>b__5>d.MoveNext() in C:\dev\git\tye\src\Tye.Hosting\ProxyService.cs:line 150
```