### PR TITLE
Use correct namespace creating secrets

### DIFF
--- a/src/Tye.Core/ValidateSecretStep.cs
+++ b/src/Tye.Core/ValidateSecretStep.cs
@@ -52,6 +52,12 @@ namespace Tye
                     output.WriteDebugLine($"Validating secret '{secretInputBinding.Name}'.");
 
                     var config = KubernetesClientConfiguration.BuildDefaultConfig();
+
+                    // Workaround for https://github.com/kubernetes-client/csharp/issues/372
+                    var store = KubernetesClientConfiguration.LoadKubeConfig();
+                    var context = store.Contexts.Where(c => c.Name == config.CurrentContext).FirstOrDefault();
+                    config.Namespace ??= context?.ContextDetails?.Namespace;
+
                     var kubernetes = new Kubernetes(config);
 
                     try


### PR DESCRIPTION
Fixes: #111

This is a workaround for
https://github.com/kubernetes-client/csharp/issues/372

The kubernetes client isn't populating this property even though it
does read it (elsewhere in the OM).