### PR TITLE
Update ElasticSearch.Net

### DIFF
--- a/src/Tye.Hosting.Diagnostics/Tye.Hosting.Diagnostics.csproj
+++ b/src/Tye.Hosting.Diagnostics/Tye.Hosting.Diagnostics.csproj
@@ -7,17 +7,25 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
+  <ItemGroup Label="Pinned">
+    <!--
+      Packages here are pinned to higher versions so that we're using versions that
+      are not vulnerable.
+    -->
+    <PackageReference Include="ElasticSearch.Net" Version="7.6.1" />
+  </ItemGroup>
+
   <ItemGroup>
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.49" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.61701" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.12.0" />
+    <PackageReference Include="OpenTelemetry" Version="0.2.0-alpha.173" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="0.2.0-alpha.173" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.0.1" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.49" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.61701" />
-    <PackageReference Include="OpenTelemetry" Version="0.2.0-alpha.173" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="0.2.0-alpha.173" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updating ElasticSearch.Net. The one included with
Serilog.Sinks.ElasticSearch has vulerabilities.