### PR TITLE
Remove access token from redis docs

### DIFF
--- a/docs/redis.md
+++ b/docs/redis.md
@@ -119,7 +119,7 @@ We just showed how `tye` makes it easier to communicate between 2 applications r
     `tye deploy` will not deploy the redis configuration, so you need to deploy it first. Run:
 
     ```text
-    kubectl apply -f https://raw.githubusercontent.com/dotnet/tye/master/docs/yaml/redis.yaml?token=AAK5D65XGABGEPUJ2MFJBM26O35M2
+    kubectl apply -f https://raw.githubusercontent.com/dotnet/tye/master/docs/yaml/redis.yaml
     ```
 
     This will create a deployment and service for redis. You can see that by running:


### PR DESCRIPTION
This is no longer needed now that we're public.