### PR TITLE
Added support for volume mapping docker containers

### DIFF
--- a/src/Microsoft.Tye.Hosting/DockerRunner.cs
+++ b/src/Microsoft.Tye.Hosting/DockerRunner.cs
@@ -129,7 +129,8 @@ namespace Microsoft.Tye.Hosting
 
                 foreach (var pair in docker.VolumeMappings)
                 {
-                    volumes += $"-v {pair.Key}:{pair.Value} ";
+                    var sourcePath = Path.GetFullPath(Path.Combine(application.ContextDirectory, pair.Key.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)));
+                    volumes += $"-v {sourcePath}:{pair.Value} ";
                 }
 
                 var command = $"run -d {workingDirectory} {volumes} {environmentArguments} {portString} --name {replica} --restart=unless-stopped {docker.Image} {docker.Args ?? ""}";

--- a/src/Microsoft.Tye.Hosting/Model/ProjectRunInfo.cs
+++ b/src/Microsoft.Tye.Hosting/Model/ProjectRunInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Tye.Hosting.Model
 {
     public class ProjectRunInfo : RunInfo
@@ -16,5 +18,8 @@ namespace Microsoft.Tye.Hosting.Model
         public string? Args { get; }
         public bool Build { get; }
         public string Project { get; }
+
+        // This exists for running projects as containers
+        public Dictionary<string, string> VolumeMappings { get; } = new Dictionary<string, string>();
     }
 }

--- a/src/Microsoft.Tye.Hosting/TransformProjectsIntoContainers.cs
+++ b/src/Microsoft.Tye.Hosting/TransformProjectsIntoContainers.cs
@@ -75,6 +75,12 @@ namespace Microsoft.Tye.Hosting
             };
             dockerRunInfo.VolumeMappings[Path.GetDirectoryName(service.Status.ProjectFilePath)!] = "/app";
 
+            // Make volume mapping works when running as a container
+            foreach (var mapping in project.VolumeMappings)
+            {
+                dockerRunInfo.VolumeMappings[mapping.Key] = mapping.Value;
+            }
+
             // Change the project into a container info
             serviceDescription.RunInfo = dockerRunInfo;
         }

--- a/src/tye/ConfigModel/ConfigApplication.cs
+++ b/src/tye/ConfigModel/ConfigApplication.cs
@@ -34,7 +34,14 @@ namespace Microsoft.Tye.ConfigModel
                 }
                 else if (service.DockerImage is object)
                 {
-                    runInfo = new DockerRunInfo(service.DockerImage, service.Args);
+                    var dockerRunInfo = new DockerRunInfo(service.DockerImage, service.Args);
+
+                    foreach (var mapping in service.Volumes)
+                    {
+                        dockerRunInfo.VolumeMappings[mapping.Source!] = mapping.Target!;
+                    }
+
+                    runInfo = dockerRunInfo;
                 }
                 else if (service.Executable is object)
                 {
@@ -42,7 +49,14 @@ namespace Microsoft.Tye.ConfigModel
                 }
                 else if (service.Project is object)
                 {
-                    runInfo = new ProjectRunInfo(service.Project, service.Args, service.Build ?? true);
+                    var projectInfo = new ProjectRunInfo(service.Project, service.Args, service.Build ?? true);
+
+                    foreach (var mapping in service.Volumes)
+                    {
+                        projectInfo.VolumeMappings[mapping.Source!] = mapping.Target!;
+                    }
+
+                    runInfo = projectInfo;
                 }
                 else
                 {

--- a/src/tye/ConfigModel/ConfigService.cs
+++ b/src/tye/ConfigModel/ConfigService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Tye.ConfigModel
         public string? Args { get; set; }
         public int? Replicas { get; set; }
         public List<ConfigServiceBinding> Bindings { get; set; } = new List<ConfigServiceBinding>();
-
+        public List<ConfigVolume> Volumes { get; set; } = new List<ConfigVolume>();
         [YamlMember(Alias = "env")]
         public List<ConfigConfigurationSource> Configuration { get; set; } = new List<ConfigConfigurationSource>();
     }

--- a/src/tye/ConfigModel/ConfigVolume.cs
+++ b/src/tye/ConfigModel/ConfigVolume.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Tye.ConfigModel
+{
+    public class ConfigVolume
+    {
+        public string? Source { get; set; }
+        public string? Target { get; set; }
+    }
+}

--- a/src/tye/InitHost.cs
+++ b/src/tye/InitHost.cs
@@ -75,6 +75,7 @@ services:
                     {
                         service.Bindings = null!;
                         service.Configuration = null!;
+                        service.Volumes = null!;
                         service.Project = service.Project!.Substring(directory.FullName.Length).TrimStart('/');
                     }
 

--- a/src/tye/tye.csproj
+++ b/src/tye/tye.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>Tye</RootNamespace>
+    <RootNamespace>Microsoft.Tye</RootNamespace>
     <AssemblyName>tye</AssemblyName>
     <PackageId>Microsoft.Tye</PackageId>
     <ToolCommandName>tye</ToolCommandName>


### PR DESCRIPTION
- This also works when you run projects as containers.

```yaml
services:
- name: myservice
  dockerImage: davidfowl/gohello
  bindings:
     - autoAssignPort: true
  volumes:
    - source: foo
      target: /foo
```

Once we start using  the yaml reader, we can support the docker compose syntax as well (`{source}:{target}`)