### PR TITLE
Don't assume executables are relative to the context directory.

### DIFF
--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -75,7 +75,9 @@ namespace Microsoft.Tye.Hosting
             else if (serviceDescription.RunInfo is ExecutableRunInfo executable)
             {
                 var expandedExecutable = Environment.ExpandEnvironmentVariables(executable.Executable);
-                path = Path.GetFullPath(Path.Combine(application.ContextDirectory, expandedExecutable));
+                path = Path.GetExtension(expandedExecutable) == ".dll" ?
+                    Path.GetFullPath(Path.Combine(application.ContextDirectory, expandedExecutable)) :
+                    expandedExecutable;
                 workingDirectory = executable.WorkingDirectory != null ?
                     Path.GetFullPath(Path.Combine(application.ContextDirectory, Environment.ExpandEnvironmentVariables(executable.WorkingDirectory))) :
                     Path.GetDirectoryName(path)!;


### PR DESCRIPTION
- This allows running executables that are on the path.

```yaml
services:
- name: myservice
  executable: node
  args: app.js
```