### PR TITLE
Allow shutting down even if startup fails.

### DIFF
--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -123,6 +123,9 @@ namespace Microsoft.Tye.Hosting
 
             async Task RunApplicationAsync(IEnumerable<(int Port, int BindingPort, string? Protocol)> ports)
             {
+                // Make sure we yield before trying to start the process, this is important so we don't hang startup
+                await Task.Yield();
+
                 var hasPorts = ports.Any();
 
                 var environment = new Dictionary<string, string>


### PR DESCRIPTION
- Running a process starts a loop directly when starting up, instead of it should yield so that StartAsync can return.