### PR TITLE
Minor white-space, typo, structured logging, and consistent usage of 'Dockerfile' changes

### DIFF
--- a/src/Microsoft.Tye.Core/ContainerInfo.cs
+++ b/src/Microsoft.Tye.Core/ContainerInfo.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Tye
         public string? ImageTag { get; set; }
 
         /// <summary>
-        /// Gets or a sets value which determines whether a multiphase dockerfile is used.
+        /// Gets or a sets value which determines whether a multi-phase Dockerfile is used.
         /// </summary>
         public bool? UseMultiphaseDockerfile { get; set; }
     }

--- a/src/Microsoft.Tye.Core/DeployServiceYamlStep.cs
+++ b/src/Microsoft.Tye.Core/DeployServiceYamlStep.cs
@@ -71,6 +71,3 @@ namespace Microsoft.Tye
         }
     }
 }
-
-
-

--- a/src/Microsoft.Tye.Core/DockerContainerBuilder.cs
+++ b/src/Microsoft.Tye.Core/DockerContainerBuilder.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Tye
             var dockerFilePath = Path.Combine(application.GetProjectDirectory(project), Path.GetDirectoryName(project.RelativeFilePath)!, "Dockerfile");
             if (File.Exists(dockerFilePath))
             {
-                output.WriteDebugLine($"Using existing dockerfile '{dockerFilePath}'.");
+                output.WriteDebugLine($"Using existing Dockerfile '{dockerFilePath}'.");
             }
             else
             {
@@ -52,7 +52,7 @@ namespace Microsoft.Tye
                 dockerFilePath = tempFile.FilePath;
             }
 
-            // We need to know if this is a single-phase or multi-phase dockerfile because the context directory will be
+            // We need to know if this is a single-phase or multi-phase Dockerfile because the context directory will be
             // different depending on that choice.
             string contextDirectory;
             if (container.UseMultiphaseDockerfile ?? true)
@@ -64,7 +64,7 @@ namespace Microsoft.Tye
                 var publishOutput = service.Outputs.OfType<ProjectPublishOutput>().FirstOrDefault();
                 if (publishOutput is null)
                 {
-                    throw new InvalidOperationException("We should have published the project for a single-phase dockerfile.");
+                    throw new InvalidOperationException("We should have published the project for a single-phase Dockerfile.");
                 }
 
                 contextDirectory = publishOutput.Directory.FullName;

--- a/src/Microsoft.Tye.Core/DockerfileGenerator.cs
+++ b/src/Microsoft.Tye.Core/DockerfileGenerator.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Tye
             using var writer = new StreamWriter(stream, encoding: Encoding.UTF8, bufferSize: -1, leaveOpen: true);
 
             var entryPoint = Path.GetFileNameWithoutExtension(project.RelativeFilePath);
-            output.WriteDebugLine($"Writing dockerfile to '{filePath}'.");
+            output.WriteDebugLine($"Writing Dockerfile to '{filePath}'.");
             if (container.UseMultiphaseDockerfile ?? true)
             {
                 await WriteMultiphaseDockerfileAsync(writer, entryPoint, container);
@@ -57,7 +57,7 @@ namespace Microsoft.Tye
             {
                 await WriteLocalPublishDockerfileAsync(writer, entryPoint, container);
             }
-            output.WriteDebugLine("Done writing dockerfile.");
+            output.WriteDebugLine("Done writing Dockerfile.");
         }
 
         private static async Task WriteMultiphaseDockerfileAsync(StreamWriter writer, string applicationEntryPoint, ContainerInfo container)

--- a/src/Microsoft.Tye.Core/PublishProjectStep.cs
+++ b/src/Microsoft.Tye.Core/PublishProjectStep.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Tye
 {
-    // Used to publish a project when using a single-file dockerfile
+    // Used to publish a project when using a single-phase Dockerfile
     public class PublishProjectStep : ServiceExecutor.Step
     {
         public override string DisplayText => "Publishing Project...";

--- a/src/Microsoft.Tye.Core/StandardOptions.cs
+++ b/src/Microsoft.Tye.Core/StandardOptions.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Tye
         {
             get
             {
-                return new Option(new[] { "-v", "--verbosity" }, "Output verbostiy")
+                return new Option(new[] { "-v", "--verbosity" }, "Output verbosity")
                 {
                     Argument = new Argument<Verbosity>("one of: quiet|info|debug", () => Tye.Verbosity.Info)
                     {

--- a/src/Microsoft.Tye.Hosting/TransformProjectsIntoContainers.cs
+++ b/src/Microsoft.Tye.Hosting/TransformProjectsIntoContainers.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Tye.Hosting
 
         public Task StartAsync(Model.Application application)
         {
-            // This transforms a ProjectRunInfo into
+            // This transforms a ProjectRunInfo into a container
             var tasks = new List<Task>();
             foreach (var s in application.Services.Values)
             {

--- a/src/Microsoft.Tye.Hosting/TyeHost.cs
+++ b/src/Microsoft.Tye.Hosting/TyeHost.cs
@@ -192,13 +192,13 @@ namespace Microsoft.Tye.Hosting
             else if (IsPortInUseByBinding(_application, DefaultPort))
             {
                 // Port has been reserved for the app.
-                app.Logger.LogInformation($"Default dashboard port {DefaultPort} has been reserved by the application, choosing random port.");
+                app.Logger.LogInformation("Default dashboard port {DefaultPort} has been reserved by the application, choosing random port.", DefaultPort);
                 return AutodetectPort;
             }
             else if (IsPortAlreadyInUse(DefaultPort))
             {
                 // Port is in use by something already running.
-                app.Logger.LogInformation($"Default dashboard port {DefaultPort} is in use, choosing random port.");
+                app.Logger.LogInformation("Default dashboard port {DefaultPort} is in use, choosing random port.", DefaultPort);
                 return AutodetectPort;
             }
             else
@@ -254,7 +254,7 @@ namespace Microsoft.Tye.Hosting
                 new ProcessRunner(logger, ProcessRunnerOptions.FromArgs(args)),
             };
 
-            // If the docker command is specified then transport the ProjectRunInfo into DockerRunInfo
+            // If the docker command is specified then transform the ProjectRunInfo into DockerRunInfo
             if (args.Contains("--docker"))
             {
                 processors.Insert(0, new TransformProjectsIntoContainers(logger));

--- a/src/tye/CommonArguments.cs
+++ b/src/tye/CommonArguments.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Tye
 
                 if (files.Length > 1)
                 {
-                    errorMessage = $"More than one matching files was found in directory '{directoryPath}'.";
+                    errorMessage = $"More than one matching file was found in directory '{directoryPath}'.";
                     filePath = default;
                     return false;
                 }

--- a/src/tye/Program.BuildCommand.cs
+++ b/src/tye/Program.BuildCommand.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Tye
     {
         public static Command CreateBuildCommand()
         {
-            var command = new Command("build", "build container for the application")
+            var command = new Command("build", "build containers for the application")
             {
                 CommonArguments.Path_Required,
                 StandardOptions.Interactive,


### PR DESCRIPTION
Minor white-space, typo, structured logging, and consistent usage of 'Dockerfile' (and multi/single-phase) pass.

Also, addressed a couple typos in the CLI output in the help text.