### PR TITLE
Fix tests

### DIFF
--- a/src/Microsoft.Tye.Core/Microsoft.Tye.Core.csproj
+++ b/src/Microsoft.Tye.Core/Microsoft.Tye.Core.csproj
@@ -16,7 +16,7 @@
       The Microsoft.Build.Locator package takes care of dynamically loading these assemblies
       at runtime. We don't need/want to ship them, just to have them as references.
     -->
-    <PackageReference Include="Microsoft.Build" Version="16.5.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build" Version="16.3.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
     <!-- Hoisted to avoid a conflict with Microsoft.Build -->
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />

--- a/src/Microsoft.Tye.Hosting/DockerRunner.cs
+++ b/src/Microsoft.Tye.Hosting/DockerRunner.cs
@@ -129,6 +129,10 @@ namespace Microsoft.Tye.Hosting
                     environment["PORT"] = string.Join(";", ports.Select(p => $"{p.InternalPort ?? p.Port}"));
                 }
 
+                // See: https://github.com/docker/for-linux/issues/264
+                //
+                // The way we do proxying here doesn't really work for multi-container scenarios on linux
+                // without some more setup.
                 application.PopulateEnvironment(service, (key, value) => environment[key] = value, "host.docker.internal");
 
                 environment["APP_INSTANCE"] = replica;

--- a/src/Microsoft.Tye.Hosting/Microsoft.Tye.Hosting.csproj
+++ b/src/Microsoft.Tye.Hosting/Microsoft.Tye.Hosting.csproj
@@ -19,7 +19,6 @@
   <ItemGroup>
     <PackageReference Include="Bedrock.Framework" Version="0.1.38-alpha.gd25d5b37ad" />
     <PackageReference Include="FeatherHttp" Version="0.1.42-alpha.gf06a8747e7" />
-    <PackageReference Include="Microsoft.Build" Version="16.5.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/tye/ConfigModel/ConfigFactory.cs
+++ b/src/tye/ConfigModel/ConfigFactory.cs
@@ -57,25 +57,11 @@ namespace Microsoft.Tye.ConfigModel
                 Source = file,
             };
 
-            var solution = SolutionFile.Parse(file.FullName);
-            foreach (var project in solution.ProjectsInOrder)
+            // BE CAREFUL modifying this code. Avoid proliferating MSBuild types
+            // throughout the code, because we load them dynamically.
+            foreach (var projectFile in ProjectReader.EnumerateProjects(file))
             {
-                if (project.ProjectType != SolutionProjectType.KnownToBeMSBuildFormat)
-                {
-                    continue;
-                }
-
-                var extension = Path.GetExtension(project.AbsolutePath).ToLower();
-                switch (extension)
-                {
-                    case ".csproj":
-                    case ".fsproj":
-                        break;
-                    default:
-                        continue;
-                }
-
-                var description = CreateService(new FileInfo(project.AbsolutePath.Replace('\\', '/')));
+                var description = CreateService(projectFile);
                 if (description != null)
                 {
                     application.Services.Add(description);

--- a/test/E2ETest/E2ETest.csproj
+++ b/test/E2ETest/E2ETest.csproj
@@ -14,6 +14,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+      The Microsoft.Build.Locator package takes care of dynamically loading these assemblies
+      at runtime. We don't need/want to ship them, just to have them as references.
+    -->
+    <PackageReference Include="Microsoft.Build" Version="16.3.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.3.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Tye.Hosting\Microsoft.Tye.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Tye.Core\Microsoft.Tye.Core.csproj" />
     <ProjectReference Include="..\..\src\tye\tye.csproj" />

--- a/test/E2ETest/Infrastructure/ConditionalFactAttribute.cs
+++ b/test/E2ETest/Infrastructure/ConditionalFactAttribute.cs
@@ -5,7 +5,7 @@ using Xunit.Sdk;
 namespace E2ETest
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    [XunitTestCaseDiscoverer("E2ETest." + nameof(ConditionalFactDiscoverer), "E2ETest")]
+    [XunitTestCaseDiscoverer("E2ETest." + nameof(ConditionalFactDiscoverer), "Microsoft.Tye.E2ETest")]
     public class ConditionalFactAttribute : FactAttribute
     {
     }

--- a/test/E2ETest/Infrastructure/SkipOnLinuxAttribute.cs
+++ b/test/E2ETest/Infrastructure/SkipOnLinuxAttribute.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace E2ETest
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
+    internal class SkipOnLinuxAttribute : Attribute, ITestCondition
+    {
+        public SkipOnLinuxAttribute()
+        {
+            IsMet = !RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            SkipReason = "This is linux. Here's a free bus-ticket to skipsville.";
+        }
+
+        public bool IsMet { get; }
+
+        public string SkipReason { get; set; }
+    }
+}

--- a/test/E2ETest/TestOutputLogEventSink.cs
+++ b/test/E2ETest/TestOutputLogEventSink.cs
@@ -32,7 +32,8 @@ namespace E2ETest
 
         public void Write(string value)
         {
-            output.WriteLine(value);
+            // our usage of IConsole includes newlines, so strip them out.
+            output.WriteLine(value.TrimEnd('\r', '\n'));
         }
     }
 }

--- a/test/E2ETest/testassets/generate/frontend-backend.yaml
+++ b/test/E2ETest/testassets/generate/frontend-backend.yaml
@@ -23,6 +23,8 @@ spec:
         env:
         - name: ASPNETCORE_URLS
           value: 'http://*'
+        - name: PORT
+          value: '80'
         - name: SERVICE__FRONTEND__PROTOCOL
           value: 'http'
         - name: SERVICE__FRONTEND__PORT
@@ -76,6 +78,8 @@ spec:
         env:
         - name: ASPNETCORE_URLS
           value: 'http://*'
+        - name: PORT
+          value: '80'
         - name: SERVICE__BACKEND__PROTOCOL
           value: 'http'
         - name: SERVICE__BACKEND__PORT

--- a/test/E2ETest/testassets/generate/multi-project.yaml
+++ b/test/E2ETest/testassets/generate/multi-project.yaml
@@ -23,6 +23,8 @@ spec:
         env:
         - name: ASPNETCORE_URLS
           value: 'http://*:7000'
+        - name: PORT
+          value: '7000'
         - name: SERVICE__FRONTEND__PROTOCOL
           value: 'http'
         - name: SERVICE__FRONTEND__PORT
@@ -87,6 +89,8 @@ spec:
         env:
         - name: ASPNETCORE_URLS
           value: 'http://*:8000'
+        - name: PORT
+          value: '8000'
         - name: SERVICE__BACKEND__PROTOCOL
           value: 'http'
         - name: SERVICE__BACKEND__PORT

--- a/test/E2ETest/testassets/generate/single-project-noregistry.yaml
+++ b/test/E2ETest/testassets/generate/single-project-noregistry.yaml
@@ -23,6 +23,8 @@ spec:
         env:
         - name: ASPNETCORE_URLS
           value: 'http://*'
+        - name: PORT
+          value: '80'
         ports:
         - containerPort: 80
 ...

--- a/test/E2ETest/testassets/generate/single-project.yaml
+++ b/test/E2ETest/testassets/generate/single-project.yaml
@@ -23,6 +23,8 @@ spec:
         env:
         - name: ASPNETCORE_URLS
           value: 'http://*'
+        - name: PORT
+          value: '80'
         ports:
         - containerPort: 80
 ...


### PR DESCRIPTION
Multiple issues fixed here:

- xUnit silently ignores invalid `TestDiscoverers` so all of our conditional tests have been ignored, not skipped, ignored.
- Docker run test times out on the initial HTTP request really eagerly, so it will only pass if the image is already cached
- Docker on macOS doesn't have access to `/var...` which is where .NET puts temp files
- We need to downgrade the version of MSBuild to be compatible with what's the the SDK. Your guess is as good as mine about why this works standalone, but not in unit tests
- Need to make MSBuild discovery logic thread-safe 
- Added lots of logging for new MSBuild stuff
- Make MSBuild code resiliant to loading the same project multiple times in process (like in tests)
- Cleaned up logging to not have so many extra lines
- Fixed generated baselines that were out of date