### PR TITLE
Fix NullRef in Tye run when not specifying and projects to debug.

### DIFF
--- a/src/Microsoft.Tye.Hosting/ProcessRunnerOptions.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunnerOptions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Tye.Hosting
                 BuildProjects = !args.Contains("--no-build"),
                 DebugMode = args.Contains("--debug"),
                 ServicesToDebug = servicesToDebug,
-                DebugAllServices = servicesToDebug.Contains("*", StringComparer.OrdinalIgnoreCase)
+                DebugAllServices = servicesToDebug?.Contains("*", StringComparer.OrdinalIgnoreCase) ?? false
             };
         }
     }

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -175,6 +175,26 @@ namespace E2ETest
             }
         }
 
+        [Fact]
+        public async Task NullDebugTargetsDoesNotThrow()
+        {
+            var projectDirectory = new DirectoryInfo(Path.Combine(TestHelpers.GetSolutionRootDirectory("tye"), "samples", "single-project", "test-project"));
+            using var tempDirectory = TempDirectory.Create();
+            DirectoryCopy.Copy(projectDirectory.FullName, tempDirectory.DirectoryPath);
+
+            var projectFile = new FileInfo(Path.Combine(tempDirectory.DirectoryPath, "test-project.csproj"));
+
+            // Debug targets can be null if not specified, so make sure calling host.Start does not throw.
+            using var host = new TyeHost(ConfigFactory.FromFile(projectFile).ToHostingApplication(), Array.Empty<string>(), null!)
+            {
+                Sink = sink,
+            };
+
+            await host.StartAsync();
+
+            await host.StopAsync();
+        }
+
         private async Task CheckServiceIsUp(Microsoft.Tye.Hosting.Model.Application application, HttpClient client, string serviceName, Uri dashboardUri, TimeSpan? timeout = default)
         {
             // make sure backend is up before frontend


### PR DESCRIPTION
Should have tested doing `tye run` without debugging projects. Whoops.