### PR TITLE
Use msbuild project info for running

### DIFF
--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Tye
                 ServiceBuilder service;
                 if (!string.IsNullOrEmpty(configService.Project))
                 {
-                    var projectFile = new FileInfo(Path.Combine(builder.Source.DirectoryName, configService.Project));
+                    var expandedProject = Environment.ExpandEnvironmentVariables(configService.Project);
+                    var projectFile = new FileInfo(Path.Combine(builder.Source.DirectoryName, expandedProject));
                     var project = new ProjectServiceBuilder(configService.Name, projectFile);
                     service = project;
 

--- a/src/Microsoft.Tye.Core/ProjectReader.cs
+++ b/src/Microsoft.Tye.Core/ProjectReader.cs
@@ -201,6 +201,11 @@ namespace Microsoft.Tye
             project.PublishDir = projectInstance.GetPropertyValue("PublishDir");
             project.AssemblyName = projectInstance.GetPropertyValue("AssemblyName");
 
+            output.WriteDebugLine($"RunCommand={project.RunCommand}");
+            output.WriteDebugLine($"TargetPath={project.TargetPath}");
+            output.WriteDebugLine($"PublishDir={project.PublishDir}");
+            output.WriteDebugLine($"AssemblyName={project.AssemblyName}");
+
             var targetFramework = projectInstance.GetPropertyValue("TargetFramework");
             project.TargetFramework = targetFramework;
             output.WriteDebugLine($"Found target framework: {targetFramework}");

--- a/src/Microsoft.Tye.Core/ProjectReader.cs
+++ b/src/Microsoft.Tye.Core/ProjectReader.cs
@@ -193,6 +193,14 @@ namespace Microsoft.Tye
             project.Version = version;
             output.WriteDebugLine($"Found application version: {version}");
 
+            var targetFrameworks = projectInstance.GetPropertyValue("TargetFrameworks");
+            project.TargetFrameworks = targetFrameworks.Split(';', StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
+
+            project.RunCommand = projectInstance.GetPropertyValue("RunCommand");
+            project.TargetPath = projectInstance.GetPropertyValue("TargetPath");
+            project.PublishDir = projectInstance.GetPropertyValue("PublishDir");
+            project.AssemblyName = projectInstance.GetPropertyValue("AssemblyName");
+
             var targetFramework = projectInstance.GetPropertyValue("TargetFramework");
             project.TargetFramework = targetFramework;
             output.WriteDebugLine($"Found target framework: {targetFramework}");

--- a/src/Microsoft.Tye.Core/ProjectReader.cs
+++ b/src/Microsoft.Tye.Core/ProjectReader.cs
@@ -197,11 +197,13 @@ namespace Microsoft.Tye
             project.TargetFrameworks = targetFrameworks.Split(';', StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
 
             project.RunCommand = projectInstance.GetPropertyValue("RunCommand");
+            project.RunArguments = projectInstance.GetPropertyValue("RunArguments");
             project.TargetPath = projectInstance.GetPropertyValue("TargetPath");
             project.PublishDir = projectInstance.GetPropertyValue("PublishDir");
             project.AssemblyName = projectInstance.GetPropertyValue("AssemblyName");
 
             output.WriteDebugLine($"RunCommand={project.RunCommand}");
+            output.WriteDebugLine($"RunArguments={project.RunArguments}");
             output.WriteDebugLine($"TargetPath={project.TargetPath}");
             output.WriteDebugLine($"PublishDir={project.PublishDir}");
             output.WriteDebugLine($"AssemblyName={project.AssemblyName}");

--- a/src/Microsoft.Tye.Core/ProjectServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/ProjectServiceBuilder.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 
 namespace Microsoft.Tye
@@ -39,6 +40,9 @@ namespace Microsoft.Tye
 
         // This is always set on the ApplicationFactory codepath.
         public string RunCommand { get; set; } = default!;
+
+        // This is always set on the ApplicationFactory codepath.
+        public string RunArguments { get; set; } = default!;
 
         // This is always set on the ApplicationFactory codepath.
         public string AssemblyName { get; set; } = default!;

--- a/src/Microsoft.Tye.Core/ProjectServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/ProjectServiceBuilder.cs
@@ -29,7 +29,22 @@ namespace Microsoft.Tye
         public string TargetFramework { get; set; } = default!;
 
         // This is always set on the ApplicationFactory codepath.
+        public string[] TargetFrameworks { get; set; } = default!;
+
+        // This is always set on the ApplicationFactory codepath.
         public string Version { get; set; } = default!;
+
+        // This is always set on the ApplicationFactory codepath.
+        public string TargetPath { get; set; } = default!;
+
+        // This is always set on the ApplicationFactory codepath.
+        public string RunCommand { get; set; } = default!;
+
+        // This is always set on the ApplicationFactory codepath.
+        public string AssemblyName { get; set; } = default!;
+
+        // This is always set on the ApplicationFactory codepath.
+        public string PublishDir { get; set; } = default!;
 
         // Data used for building containers
         public ContainerInfo? ContainerInfo { get; set; }

--- a/src/Microsoft.Tye.Hosting/Dashboard/Pages/Index.razor
+++ b/src/Microsoft.Tye.Hosting/Dashboard/Pages/Index.razor
@@ -28,7 +28,7 @@
                 <td>
                     @if (service.Description.RunInfo is ProjectRunInfo project)
                     {
-                        <p>@project.Project</p>
+                        <p>@project.ProjectFile.FullName</p>
                     }
                     else if (service.Description.RunInfo is DockerRunInfo docker)
                     {

--- a/src/Microsoft.Tye.Hosting/Model/ProjectRunInfo.cs
+++ b/src/Microsoft.Tye.Hosting/Model/ProjectRunInfo.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Tye.Hosting.Model
             Version = project.Version;
             AssemblyName = project.AssemblyName;
             TargetAssemblyPath = Path.Combine(project.ProjectFile.Directory.Name, project.TargetPath);
-            RunCommand =  project.RunCommand;
+            RunCommand = project.RunCommand;
             PublishOutputPath = Path.Combine(project.ProjectFile.Directory.Name, project.PublishDir);
         }
 
@@ -31,7 +31,7 @@ namespace Microsoft.Tye.Hosting.Model
         public string Version { get; }
 
         public string AssemblyName { get; }
-        
+
         public string TargetAssemblyPath { get; }
 
         public string PublishOutputPath { get; }

--- a/src/Microsoft.Tye.Hosting/Model/ProjectRunInfo.cs
+++ b/src/Microsoft.Tye.Hosting/Model/ProjectRunInfo.cs
@@ -3,21 +3,40 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
 
 namespace Microsoft.Tye.Hosting.Model
 {
     public class ProjectRunInfo : RunInfo
     {
-        public ProjectRunInfo(string project, string? args, bool build)
+        public ProjectRunInfo(ProjectServiceBuilder project)
         {
-            Project = project;
-            Args = args;
-            Build = build;
+            ProjectFile = project.ProjectFile;
+            Args = project.Args;
+            Build = project.Build;
+            TargetFramework = project.TargetFramework;
+            Version = project.Version;
+            AssemblyName = project.AssemblyName;
+            TargetAssemblyPath = Path.Combine(project.ProjectFile.Directory.Name, project.TargetPath);
+            RunCommand =  project.RunCommand;
+            PublishOutputPath = Path.Combine(project.ProjectFile.Directory.Name, project.PublishDir);
         }
 
         public string? Args { get; }
         public bool Build { get; }
-        public string Project { get; }
+        public FileInfo ProjectFile { get; }
+
+        public string TargetFramework { get; }
+
+        public string Version { get; }
+
+        public string AssemblyName { get; }
+        
+        public string TargetAssemblyPath { get; }
+
+        public string PublishOutputPath { get; }
+
+        public string RunCommand { get; }
 
         // This exists for running projects as containers
         public Dictionary<string, string> VolumeMappings { get; } = new Dictionary<string, string>();

--- a/src/Microsoft.Tye.Hosting/Model/ProjectRunInfo.cs
+++ b/src/Microsoft.Tye.Hosting/Model/ProjectRunInfo.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Tye.Hosting.Model
             AssemblyName = project.AssemblyName;
             TargetAssemblyPath = Path.Combine(project.ProjectFile.Directory.Name, project.TargetPath);
             RunCommand = project.RunCommand;
+            RunArguments = project.RunArguments;
             PublishOutputPath = Path.Combine(project.ProjectFile.Directory.Name, project.PublishDir);
         }
 
@@ -37,6 +38,7 @@ namespace Microsoft.Tye.Hosting.Model
         public string PublishOutputPath { get; }
 
         public string RunCommand { get; }
+        public string RunArguments { get; }
 
         // This exists for running projects as containers
         public Dictionary<string, string> VolumeMappings { get; } = new Dictionary<string, string>();

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -60,12 +60,10 @@ namespace Microsoft.Tye.Hosting
 
             if (serviceDescription.RunInfo is ProjectRunInfo project)
             {
-                var expandedProject = Environment.ExpandEnvironmentVariables(project.Project);
-                var fullProjectPath = Path.GetFullPath(Path.Combine(application.ContextDirectory, expandedProject));
-                path = GetExePath(fullProjectPath);
-                workingDirectory = Path.GetDirectoryName(fullProjectPath)!;
+                path = project.RunCommand;
+                workingDirectory = project.ProjectFile.Directory.FullName;
                 args = project.Args ?? "";
-                service.Status.ProjectFilePath = fullProjectPath;
+                service.Status.ProjectFilePath = project.ProjectFile.FullName;
             }
             else if (serviceDescription.RunInfo is ExecutableRunInfo executable)
             {
@@ -295,32 +293,6 @@ namespace Microsoft.Tye.Hosting
             }
 
             return Task.WhenAll(tasks);
-        }
-
-        private static string GetExePath(string projectFilePath)
-        {
-            // TODO: Use msbuild to get the target path
-
-            var outputFileName = Path.GetFileNameWithoutExtension(projectFilePath) + (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : ".dll");
-
-            var debugOutputPath = Path.Combine(Path.GetDirectoryName(projectFilePath)!, "bin", "Debug");
-
-            var tfms = Directory.Exists(debugOutputPath) ? Directory.GetDirectories(debugOutputPath) : Array.Empty<string>();
-
-            if (tfms.Length > 0)
-            {
-                // Pick the first one
-                var path = Path.Combine(debugOutputPath, tfms[0], outputFileName);
-                if (File.Exists(path))
-                {
-                    return path;
-                }
-
-                // Older versions of .NET Core didn't have TFMs
-                return Path.Combine(debugOutputPath, tfms[0], Path.GetFileNameWithoutExtension(projectFilePath) + ".dll");
-            }
-
-            return Path.Combine(debugOutputPath, "netcoreapp3.1", outputFileName);
         }
 
         private static string? GetDotnetRoot()

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Tye.Hosting
             {
                 path = string.IsNullOrEmpty(project.RunCommand) ? project.TargetAssemblyPath : project.RunCommand;
                 workingDirectory = project.ProjectFile.Directory.FullName;
-                args = project.Args ?? "";
+                args = project.Args == null ? project.RunArguments : project.RunArguments + " " + project.Args;
                 service.Status.ProjectFilePath = project.ProjectFile.FullName;
             }
             else if (serviceDescription.RunInfo is ExecutableRunInfo executable)

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Tye.Hosting
 
             if (serviceDescription.RunInfo is ProjectRunInfo project)
             {
-                path = project.RunCommand;
+                path = string.IsNullOrEmpty(project.RunCommand) ? project.TargetAssemblyPath : project.RunCommand;
                 workingDirectory = project.ProjectFile.Directory.FullName;
                 args = project.Args ?? "";
                 service.Status.ProjectFilePath = project.ProjectFile.FullName;

--- a/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
+++ b/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Tye.Hosting
                 v1RunInfo.Type = V1RunInfoType.Project;
                 v1RunInfo.Args = projectRunInfo.Args;
                 v1RunInfo.Build = projectRunInfo.Build;
-                v1RunInfo.Project = projectRunInfo.Project;
+                v1RunInfo.Project = projectRunInfo.ProjectFile.FullName;
             }
 
             var v1ServiceDescription = new V1ServiceDescription()

--- a/src/tye/ApplicationBuilderExtensions.cs
+++ b/src/tye/ApplicationBuilderExtensions.cs
@@ -52,7 +52,17 @@ namespace Microsoft.Tye.ConfigModel
                 }
                 else if (service is ProjectServiceBuilder project)
                 {
-                    var projectInfo = new ProjectRunInfo(project.ProjectFile.FullName, project.Args, project.Build);
+                    if (project.TargetFrameworks.Length > 1)
+                    {
+                        throw new InvalidOperationException($"Unable to run {project.Name}. Multi-targeted projects are not supported.");
+                    }
+
+                    if (project.RunCommand == null)
+                    {
+                        throw new InvalidOperationException($"Unable to run {project.Name}. The project does not have a run command");
+                    }
+
+                    var projectInfo = new ProjectRunInfo(project);
 
                     foreach (var mapping in project.Volumes)
                     {


### PR DESCRIPTION
- This fixes several subtle bugs around how we resolve output paths adhoc and uses msbuild to find various outputs.

Fixes #184