### PR TITLE
Assume http only for projects, not containers

### DIFF
--- a/samples/multi-project/tye.yaml
+++ b/samples/multi-project/tye.yaml
@@ -17,4 +17,3 @@ services:
   image: rabbitmq:3-management
   bindings:
     - port: 5672
-      protocol: rabbitmq

--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -93,7 +93,8 @@ namespace Microsoft.Tye
                         Protocol = configBinding.Protocol,
                     };
 
-                    if (binding.ConnectionString == null)
+                    // Assume HTTP for projects only (containers may be different)
+                    if (binding.ConnectionString == null && configService.Project != null)
                     {
                         binding.Protocol ??= "http";
                     }

--- a/src/Microsoft.Tye.Hosting/ProxyService.cs
+++ b/src/Microsoft.Tye.Hosting/ProxyService.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Tye.Hosting
                                         binding.Port = GetNextPort();
                                     }
 
-                                    if (binding.Protocol == "http" || binding.Protocol == null)
+                                    if (binding.Protocol == "http" || (binding.Protocol == null && service.ServiceType == Model.ServiceType.Project))
                                     {
                                         binding.ContainerPort = 80;
                                     }


### PR DESCRIPTION
Assume project ports are http by default but not container ports.