### PR TITLE
Two minor cleanup items

### DIFF
--- a/samples/voting/tye.yaml
+++ b/samples/voting/tye.yaml
@@ -8,8 +8,6 @@ services:
     - port: 6379
 - name: worker
   project: worker/worker.csproj
-  bindings:
-    - autoAssignPort: true
 - name: postgres
   image:  postgres
   env:

--- a/samples/voting/tye.yaml
+++ b/samples/voting/tye.yaml
@@ -8,6 +8,8 @@ services:
     - port: 6379
 - name: worker
   project: worker/worker.csproj
+  bindings:
+    - autoAssignPort: true
 - name: postgres
   image:  postgres
   env:


### PR DESCRIPTION
- Adds auto assign port to the voting sample (was accidentally stashed when I was testing)
- Increase docker stop/remove timeouts and log a warning when we failed to timeout. I frequently hit the 5 second timeout locally, sometimes taking 5 to 10 seconds to stop docker.