### PR TITLE
Change version in getting_started for tye

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -8,20 +8,20 @@ Tye is a tool that makes developing, testing, and deploying microservices and di
 2. Install tye via the following command:
 
     ```text
-    dotnet tool install -g Microsoft.Tye --version "0.1.0-alpha.20168.8" --add-source https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+    dotnet tool install -g Microsoft.Tye --version "0.1.0-alpha.20175.1" --add-source https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
     ```
 
     OR
 
     ```text
-    dotnet tool update -g Microsoft.Tye --version "0.1.0-alpha.20168.8" --add-source https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+    dotnet tool update -g Microsoft.Tye --version "0.1.0-alpha.20175.1" --add-source https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
     ```
 
 3. Verify the installation was complete by running:
 
     ```
     tye --version
-    > 0.1.0-alpha.20168.8+f45b9444d4894009bde48e2a3411a52dd09497b1
+    > 0.1.0-alpha.20175.1+6d4910b1f54b7e98100c8e65857f2baeb578de1b
     ```
 
 ## Next steps

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -118,16 +118,6 @@ Including a `project` entry marks the service as a *project*:
 - It will build and run locally using the .NET project during development. 
 - It will be packaged and deployed during deployments.
 
-#### `dockerImage` (string) (deprecated, use image instead)
-
-The name and optional tag of an image that can be run using Docker. 
-
-Including `image` marks the service as a *container*:
-
-- It will pulled and run locally using Docker during development.
-- It will not be deployed during deployment.
-
-
 #### `image` (string)
 
 The name and optional tag of an image that can be run using Docker. 

--- a/src/schema/tye-schema.json
+++ b/src/schema/tye-schema.json
@@ -179,7 +179,7 @@
                     "description": "The service name. Must be unique per-application.",
                     "type": "string"
                 },
-                "dockerImage": {
+                "image": {
                     "description": "The name of a Docker image.",
                     "type": "string"
                 },
@@ -208,7 +208,7 @@
             },
             "required": [
                 "name",
-                "dockerImage"
+                "image"
             ]
         },
         "project": {


### PR DESCRIPTION
I made sure that tye run and tye deploy work, just in case. There a few bugs (https://github.com/dotnet/tye/issues/208, https://github.com/dotnet/tye/issues/205) that have already been fixed or have had docs that are updated that don't work against previous tye versions.