### PR TITLE
Add a CORS policy to TypeHost

### DIFF
--- a/src/Microsoft.Tye.Hosting/TyeHost.cs
+++ b/src/Microsoft.Tye.Hosting/TyeHost.cs
@@ -149,6 +149,20 @@ namespace Microsoft.Tye.Hosting
                     o.FileProvider = new CompositeFileProvider(o.FileProvider, fileProvider);
                 });
 
+            builder.Services.AddCors(
+                options =>
+                {
+                    options.AddPolicy(
+                        "default",
+                        policy =>
+                        {
+                            policy
+                                .AllowAnyOrigin()
+                                .AllowAnyHeader()
+                                .AllowAnyMethod();
+                        });
+                });
+
             builder.Services.AddSingleton(application);
             var app = builder.Build();
             return app;
@@ -161,6 +175,8 @@ namespace Microsoft.Tye.Hosting
             app.Listen($"http://127.0.0.1:{port}");
 
             app.UseDeveloperExceptionPage();
+
+            app.UseCors("default");
 
             app.UseStaticFiles();
 


### PR DESCRIPTION
Add a CORS policy to MicronetesHost to allow discover backend service endpoints from a web frontend like a blazor webassembly or any javascript single page application.

In [Blorc.Core](https://github.com/WildGums/Blorc.Core) we have a configuration service that read values from configuration files that could be hosted in the web server.

_tye.development.json_

    {
      "Url": "http://127.0.0.1:5050"
    }

We can specify the environment file with a parameter in the Url. In this case http://localhost:5005?env=development

So, the Program entry point could look like this:

        var builder = WebAssemblyHostBuilder.CreateDefault(args);
        builder.RootComponents.Add<App>("app");

        builder.Services.AddBlorcCore();
        if (await builder.IsTyeConfigurationAvailable())
        {
            builder.Services.AddSingleton<IServiceDiscovery, TyeServiceDiscovery>();
        }

where could be possible use an implementation of IServiceDiscovery for Tye, to help connect client side with server side when the APIs are hosted in Tye. The TyeServiceDiscovery is a work in progress and should be available soon as part of Blorc.Core (or as isolate package). Actually, was implemented as MicronetesServiceDiscovery https://github.com/WildGums/Blorc.Micronetes

I use this approach for apps hosted in DCOS (Marathon) with a MarathonServiceDiscovery. But now is possible deploy and debug distributed service locally with Tye, so query the available endpoints from the client apps for development purpose could be a good idea.

Original Pull request in Micronetes: https://github.com/davidfowl/Micronetes/pull/55