### PR TITLE
Work around host.docker.internal not working on linux

### DIFF
--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -300,7 +300,6 @@ namespace E2ETest
 
         [ConditionalFact]
         [SkipIfDockerNotRunning]
-        [SkipOnLinux]
         public async Task FrontendBackendRunTestWithDocker()
         {
             var projectDirectory = new DirectoryInfo(Path.Combine(TestHelpers.GetSolutionRootDirectory("tye"), "samples", "frontend-backend"));


### PR DESCRIPTION
- Use the machine ip instead of host.docker.internal

PS: Will look into overwriting the host file in the container but its a tad bit hacky.

Fixes #176