### PR TITLE
Make ports go away

### DIFF
--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Tye
                         var binding = new BindingBuilder()
                         {
                             Name = configBinding.Name,
-                            AutoAssignPort = configBinding.AutoAssignPort,
+                            AutoAssignPort = configBinding.AutoAssignPort.HasValue ? configBinding.AutoAssignPort.Value : configBinding.ConnectionString == null,
                             ConnectionString = configBinding.ConnectionString,
                             Host = configBinding.Host,
                             ContainerPort = configBinding.ContainerPort,
@@ -224,7 +224,7 @@ namespace Microsoft.Tye
                 {
                     var binding = new IngressBindingBuilder()
                     {
-                        AutoAssignPort = configBinding.AutoAssignPort,
+                        AutoAssignPort = configBinding.AutoAssignPort ?? true,
                         Name = configBinding.Name,
                         Port = configBinding.Port,
                         Protocol = configBinding.Protocol ?? "http",

--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -123,14 +123,12 @@ namespace Microsoft.Tye
                     // HTTP is the default binding
                     service.Bindings.Add(new BindingBuilder()
                     {
-                        AutoAssignPort = true,
                         Protocol = "http"
                     });
 
                     service.Bindings.Add(new BindingBuilder()
                     {
                         Name = "https",
-                        AutoAssignPort = true,
                         Protocol = "https"
                     });
                 }
@@ -141,7 +139,6 @@ namespace Microsoft.Tye
                         var binding = new BindingBuilder()
                         {
                             Name = configBinding.Name,
-                            AutoAssignPort = configBinding.AutoAssignPort.HasValue ? configBinding.AutoAssignPort.Value : configBinding.ConnectionString == null,
                             ConnectionString = configBinding.ConnectionString,
                             Host = configBinding.Host,
                             ContainerPort = configBinding.ContainerPort,
@@ -224,7 +221,6 @@ namespace Microsoft.Tye
                 {
                     var binding = new IngressBindingBuilder()
                     {
-                        AutoAssignPort = configBinding.AutoAssignPort ?? true,
                         Name = configBinding.Name,
                         Port = configBinding.Port,
                         Protocol = configBinding.Protocol ?? "http",

--- a/src/Microsoft.Tye.Core/BindingBuilder.cs
+++ b/src/Microsoft.Tye.Core/BindingBuilder.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Tye
     {
         public string? Name { get; set; }
         public string? ConnectionString { get; set; }
-        public bool AutoAssignPort { get; set; }
         public int? Port { get; set; }
         public int? ContainerPort { get; set; }
         public string? Host { get; set; }

--- a/src/Microsoft.Tye.Core/CombineStep.cs
+++ b/src/Microsoft.Tye.Core/CombineStep.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Tye
                     binding.Protocol = "http";
                 }
 
-                if (binding.AutoAssignPort && binding.Port == null && binding.Protocol == "http")
+                if (binding.Port == null && binding.Protocol == "http")
                 {
                     binding.Port = 80;
                 }
@@ -87,7 +87,7 @@ namespace Microsoft.Tye
                             binding.Protocol = "http";
                         }
 
-                        if (binding.AutoAssignPort && binding.Port == null && binding.Protocol == "http")
+                        if (binding.Port == null && binding.Protocol == "http")
                         {
                             binding.Port = 80;
                         }

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigIngressBinding.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigIngressBinding.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Tye.ConfigModel
     public class ConfigIngressBinding
     {
         public string? Name { get; set; }
-        public bool AutoAssignPort { get; set; }
+        public bool? AutoAssignPort { get; set; }
         public int? Port { get; set; }
         public string? Protocol { get; set; } // HTTP or HTTPS
     }

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigIngressBinding.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigIngressBinding.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Tye.ConfigModel
     public class ConfigIngressBinding
     {
         public string? Name { get; set; }
-        public bool? AutoAssignPort { get; set; }
         public int? Port { get; set; }
         public string? Protocol { get; set; } // HTTP or HTTPS
     }

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigServiceBinding.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigServiceBinding.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Tye.ConfigModel
     {
         public string? Name { get; set; }
         public string? ConnectionString { get; set; }
-        public bool AutoAssignPort { get; set; }
+        public bool? AutoAssignPort { get; set; }
         public int? Port { get; set; }
         public int? ContainerPort { get; set; }
         public string? Host { get; set; }

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigServiceBinding.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigServiceBinding.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Tye.ConfigModel
     {
         public string? Name { get; set; }
         public string? ConnectionString { get; set; }
-        public bool? AutoAssignPort { get; set; }
         public int? Port { get; set; }
         public int? ContainerPort { get; set; }
         public string? Host { get; set; }

--- a/src/Microsoft.Tye.Core/IngressBindingBuilder.cs
+++ b/src/Microsoft.Tye.Core/IngressBindingBuilder.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Tye
     public sealed class IngressBindingBuilder
     {
         public string? Name { get; set; }
-        public bool AutoAssignPort { get; set; }
         public int? Port { get; set; }
         public string? Protocol { get; set; } // HTTP or HTTPS
     }

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -44,7 +44,6 @@ namespace Microsoft.Tye.Extensions.Dapr
                     // Listen for grpc on an auto-assigned port
                     var grpc = new BindingBuilder()
                     {
-                        AutoAssignPort = true,
                         Name = "grpc",
                         Protocol = "https",
                     };
@@ -53,7 +52,6 @@ namespace Microsoft.Tye.Extensions.Dapr
                     // Listen for http on an auto-assigned port
                     var http = new BindingBuilder()
                     {
-                        AutoAssignPort = true,
                         Name = "http",
                         Protocol = "http",
                     };
@@ -62,7 +60,6 @@ namespace Microsoft.Tye.Extensions.Dapr
                     // Listen for metrics on an auto-assigned port
                     var metrics = new BindingBuilder()
                     {
-                        AutoAssignPort = true,
                         Name = "metrics",
                         Protocol = "http",
                     };

--- a/src/Microsoft.Tye.Hosting/Model/ServiceBinding.cs
+++ b/src/Microsoft.Tye.Hosting/Model/ServiceBinding.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Tye.Hosting.Model
     {
         public string? Name { get; set; }
         public string? ConnectionString { get; set; }
-        public bool AutoAssignPort { get; set; }
         public int? Port { get; set; }
         public int? ContainerPort { get; set; }
         public string? Host { get; set; }

--- a/src/Microsoft.Tye.Hosting/PortAssigner.cs
+++ b/src/Microsoft.Tye.Hosting/PortAssigner.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Tye.Hosting
                 foreach (var binding in service.Description.Bindings)
                 {
                     // Auto assign ports if there's no connection string and no port
-                    if (binding.ConnectionString == null && binding.Port != null)
+                    if (binding.Port != null || binding.ConnectionString == null)
                     {
                         continue;
                     }

--- a/src/Microsoft.Tye.Hosting/PortAssigner.cs
+++ b/src/Microsoft.Tye.Hosting/PortAssigner.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Tye.Hosting
 
                 foreach (var binding in service.Description.Bindings)
                 {
-                    // Auto assign ports if there's no connection string and no port
-                    if (binding.Port != null || binding.ConnectionString == null)
+                    if (binding.Port != null || binding.ConnectionString != null)
                     {
+                        // Skip if there is a port or if there is a connection string
                         continue;
                     }
 

--- a/src/Microsoft.Tye.Hosting/PortAssigner.cs
+++ b/src/Microsoft.Tye.Hosting/PortAssigner.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Tye.Hosting
 
                 foreach (var binding in service.Description.Bindings)
                 {
-                    if (binding.Port == null && !binding.AutoAssignPort)
+                    // Auto assign ports if there's no connection string and no port
+                    if (binding.ConnectionString == null && binding.Port != null)
                     {
                         continue;
                     }

--- a/src/Microsoft.Tye.Hosting/PortAssigner.cs
+++ b/src/Microsoft.Tye.Hosting/PortAssigner.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Tye.Hosting
 
                 foreach (var binding in service.Description.Bindings)
                 {
-                    if (binding.Port != null || binding.ConnectionString != null)
+                    if (binding.ConnectionString != null)
                     {
                         // Skip if there is a port or if there is a connection string
                         continue;

--- a/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
+++ b/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using Microsoft.Tye.Hosting.Model;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using System.Text.Json.Serialization;
-using System.Collections.Generic;
+using Microsoft.Tye.Hosting.Model;
 using Microsoft.Tye.Hosting.Model.V1;
 
 namespace Microsoft.Tye.Hosting
@@ -97,7 +97,7 @@ namespace Microsoft.Tye.Hosting
             await JsonSerializer.SerializeAsync(context.Response.Body, serviceJson, _options);
         }
 
-        private static V1Service CreateServiceJson(Model.Service service)
+        private static V1Service CreateServiceJson(Service service)
         {
             var description = service.Description;
             var bindings = description.Bindings;
@@ -110,7 +110,6 @@ namespace Microsoft.Tye.Hosting
                 {
                     Name = binding.Name,
                     ConnectionString = binding.ConnectionString,
-                    AutoAssignPort = binding.AutoAssignPort,
                     Port = binding.Port,
                     ContainerPort = binding.ContainerPort,
                     Host = binding.Host,

--- a/src/tye/ApplicationBuilderExtensions.cs
+++ b/src/tye/ApplicationBuilderExtensions.cs
@@ -108,11 +108,10 @@ namespace Microsoft.Tye
 
                 foreach (var binding in service.Bindings)
                 {
-                    description.Bindings.Add(new Hosting.Model.ServiceBinding()
+                    description.Bindings.Add(new ServiceBinding()
                     {
                         ConnectionString = binding.ConnectionString,
                         Host = binding.Host,
-                        AutoAssignPort = binding.AutoAssignPort,
                         ContainerPort = binding.ContainerPort,
                         Name = binding.Name,
                         Port = binding.Port,
@@ -142,9 +141,8 @@ namespace Microsoft.Tye
 
                 foreach (var binding in ingress.Bindings)
                 {
-                    description.Bindings.Add(new Hosting.Model.ServiceBinding()
+                    description.Bindings.Add(new ServiceBinding()
                     {
-                        AutoAssignPort = binding.AutoAssignPort,
                         Name = binding.Name,
                         Port = binding.Port,
                         Protocol = binding.Protocol,


### PR DESCRIPTION
- Make AutoAssignPort true by default for binding and ingress. If a binding is defined auto assign the port. This will of course be ignored if there's a port defined.
- Don't auto assign a port if it's there's a connection string defined.

Allows things like this:

```yaml
services:
- name: frontend
  executable: node
  args: frontend\app.js
  bindings:
    - protocol: http
- name: backend
  executable: go
  args: run backend\main.go
  bindings:
    - protocol: http
```