### PR TITLE
Set ASPNETCORE_ENVIRONMENT to Development

### DIFF
--- a/src/Microsoft.Tye.Hosting/DockerRunner.cs
+++ b/src/Microsoft.Tye.Hosting/DockerRunner.cs
@@ -118,6 +118,7 @@ namespace Microsoft.Tye.Hosting
                 {
                     // Default to development environment
                     ["DOTNET_ENVIRONMENT"] = "Development",
+                    ["ASPNETCORE_ENVIRONMENT"] = "Development",
                     // Remove the color codes from the console output
                     ["DOTNET_LOGGING__CONSOLE__DISABLECOLORS"] = "true",
                     ["ASPNETCORE_LOGGING__CONSOLE__DISABLECOLORS"] = "true"

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -127,7 +127,8 @@ namespace Microsoft.Tye.Hosting
                 var environment = new Dictionary<string, string>
                 {
                     // Default to development environment
-                    ["DOTNET_ENVIRONMENT"] = "Development"
+                    ["DOTNET_ENVIRONMENT"] = "Development",
+                    ["ASPNETCORE_ENVIRONMENT"] = "Development",
                 };
 
                 // Set up environment variables to use the version of dotnet we're using to run


### PR DESCRIPTION
- We already set DOTNET_ENVIRONMENT which works on 3.0 and above apps but we also need to set ASPNETCORE_ENVIRONMENT for older apps.

Fixes #258