### PR TITLE
remove tyeDir from PurgeHostAndWaitForGivenReplicasToStop

### DIFF
--- a/test/E2ETest/TestHelpers.cs
+++ b/test/E2ETest/TestHelpers.cs
@@ -123,7 +123,7 @@ namespace E2ETest
             }
         }
 
-        public static async Task PurgeHostAndWaitForGivenReplicasToStop(TyeHost host, string[] replicas, string tyeDir)
+        public static async Task PurgeHostAndWaitForGivenReplicasToStop(TyeHost host, string[] replicas)
         {
             static async Task Purge(TyeHost host)
             {

--- a/test/E2ETest/TyePurgeTests.cs
+++ b/test/E2ETest/TyePurgeTests.cs
@@ -57,7 +57,7 @@ namespace E2ETest
                     Assert.Subset(new HashSet<int>(GetAllPids()), new HashSet<int>(pids));
 
                     await TestHelpers.PurgeHostAndWaitForGivenReplicasToStop(host,
-                        GetAllReplicasNames(host.Application), tyeDir.FullName);
+                        GetAllReplicasNames(host.Application));
 
                     var runningPids = new HashSet<int>(GetAllPids());
                     Assert.True(pids.All(pid => !runningPids.Contains(pid)));
@@ -105,7 +105,7 @@ namespace E2ETest
                         new HashSet<string>(containers));
 
                     await TestHelpers.PurgeHostAndWaitForGivenReplicasToStop(host,
-                        GetAllReplicasNames(host.Application), tyeDir.FullName);
+                        GetAllReplicasNames(host.Application));
 
                     var runningPids = new HashSet<int>(GetAllPids());
                     Assert.True(pids.All(pid => !runningPids.Contains(pid)));


### PR DESCRIPTION
Note this is a breaking change. 

i cant tell if this is a bug in that it isnt used. or it is future proofing for when it will be needed?