### PR TITLE
optimise IsEmptyArray

### DIFF
--- a/src/Microsoft.Tye.Core/Serialization/OmitDefaultAndEmptyArrayObjectGraphVisitor.cs
+++ b/src/Microsoft.Tye.Core/Serialization/OmitDefaultAndEmptyArrayObjectGraphVisitor.cs
@@ -23,11 +23,9 @@ namespace Microsoft.Tye.Serialization
             return type.GetTypeInfo().IsValueType ? Activator.CreateInstance(type) : null;
         }
 
-        private static bool IsEmptyArray(Type type, object? value)
+        private static bool IsEmptyArray(object? value)
         {
-            return value is object
-                && value is ICollection
-                && ((ICollection)value).Count == 0;
+            return value is ICollection collection && collection.Count == 0;
         }
 
         public override bool EnterMapping(IPropertyDescriptor key, IObjectDescriptor value, IEmitter context)
@@ -39,7 +37,7 @@ namespace Microsoft.Tye.Serialization
                 : GetDefault(key.Type);
 
             return !Equals(value.Value, defaultValue)
-                   && !IsEmptyArray(value.Type, value.Value)
+                   && !IsEmptyArray(value.Value)
                    && base.EnterMapping(key, value, context);
         }
     }


### PR DESCRIPTION
This is a minor perf tweek. but i figured it might be in the hot path, so i would submit it anyway

 * combines an `is` and a cast into a pattern match
 * which means the `value is object` should also be redundant?
 * also the type param was never used