### PR TITLE
Ban replicas + dapr locally

### DIFF
--- a/samples/dapr/tye.yaml
+++ b/samples/dapr/tye.yaml
@@ -14,5 +14,12 @@ services:
   project: products/products.csproj
 - name: store
   project: store/store.csproj
+
+# This may conflict with the redis instance that dapr manages.
+#
+# Doing a `docker ps` can show if its already running. If that's the case
+# then comment out out when running locally. 
 - name: redis
   image: redis
+  bindings: 
+  - port: 6379

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -31,6 +31,18 @@ namespace Microsoft.Tye.Extensions.Dapr
                         continue;
                     }
 
+                    // See https://github.com/dotnet/tye/issues/260
+                    // 
+                    // Currently the pub-sub pattern does not work when you have multiple replicas. Each
+                    // daprd instance expects that it has a single application to talk to. So if you're using
+                    // pub-sub this means that you'll won't get some messages.
+                    //
+                    // We have no way to know if an app is using pub-sub or not, so just block it.
+                    if (project.Replicas > 1)
+                    {
+                        throw new CommandException("Dapr support does not support multiple replicas yet for development.");
+                    }
+
                     var proxy = new ExecutableServiceBuilder($"{project.Name}-dapr", "daprd")
                     {
                         WorkingDirectory = context.Application.Source.DirectoryName,


### PR DESCRIPTION
It's against the law! using multiple replicas with dapr won't work correctly
with pub-sub until we add first-class sidecar handling to the hosting model.

This makes us fail with a reasonable error message for now.