### PR TITLE
Add support for container networking

### DIFF
--- a/docs/redis.md
+++ b/docs/redis.md
@@ -95,7 +95,7 @@ We just showed how `tye` makes it easier to communicate between 2 applications r
       - port: 6379
     - name: redis-cli
       image: redis
-      args: "redis-cli -h host.docker.internal MONITOR"
+      args: "redis-cli -h redis MONITOR"
    ```
 
     We've added 2 services to the `tye.yaml` file. The `redis` service itself and a `redis-cli` service that we will use to watch the data being sent to and retrieved from redis.

--- a/samples/mongo-sample/tye.yaml
+++ b/samples/mongo-sample/tye.yaml
@@ -1,0 +1,21 @@
+services:
+- name: mongo
+  image: mongo
+  env:
+    - name: ME_CONFIG_MONGODB_ADMINUSERNAME
+      value: root
+    - name: ME_CONFIG_MONGODB_ADMINPASSWORD
+      value: example
+  bindings:
+    - port: 27017
+- name: mongo-express
+  image: mongo-express
+  bindings:
+    - port: 8081
+      containerPort: 8081
+      protocol: http
+  env:
+    - name: ME_CONFIG_MONGODB_ADMINUSERNAME
+      value: root
+    - name: ME_CONFIG_MONGODB_ADMINPASSWORD
+      value: example

--- a/samples/redis/tye.yaml
+++ b/samples/redis/tye.yaml
@@ -1,0 +1,8 @@
+services:
+ - name: redis
+   image: redis
+   bindings:
+    - port: 6379
+ - name: redis-cli
+   image: redis
+   args: "redis-cli -h redis MONITOR"

--- a/src/Microsoft.Tye.Hosting/Dashboard/Pages/Index.razor
+++ b/src/Microsoft.Tye.Hosting/Dashboard/Pages/Index.razor
@@ -42,7 +42,7 @@
                         {
                             if (b.Port != null)
                             {
-                                if (b.Protocol == null || b.Protocol == "http" || b.Protocol == "https")
+                                if (b.Protocol == "http" || b.Protocol == "https")
                                 {
                                     var url = GetUrl(b);
                                     <span><a href="@url" target="_blank">@url</a></span>
@@ -79,7 +79,7 @@
 
     string GetUrl(ServiceBinding b)
     {
-        return $"{(b.Protocol ?? "http")}://{b.Host ?? "localhost"}:{b.Port}";
+        return $"{(b.Protocol ?? "tcp")}://{b.Host ?? "localhost"}:{b.Port}";
     }
 
     protected override void OnInitialized()

--- a/src/Microsoft.Tye.Hosting/HttpProxyService.cs
+++ b/src/Microsoft.Tye.Hosting/HttpProxyService.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Tye.Hosting
                 UseProxy = false
             }));
 
+            var ingress = new List<Service>();
+
             foreach (var service in application.Services.Values)
             {
                 var serviceDescription = service.Description;
@@ -154,12 +156,14 @@ namespace Microsoft.Tye.Hosting
 
                         conventions.WithDisplayName(rule.Service);
                     }
-                }
-            }
 
-            foreach (var app in _webApplications)
-            {
-                await app.StartAsync();
+                    await webApp.StartAsync();
+
+                    foreach (var replica in service.Replicas)
+                    {
+                        service.ReplicaEvents.OnNext(new ReplicaEvent(ReplicaState.Started, replica.Value));
+                    }
+                }
             }
         }
 

--- a/src/Microsoft.Tye.Hosting/HttpProxyService.cs
+++ b/src/Microsoft.Tye.Hosting/HttpProxyService.cs
@@ -40,8 +40,6 @@ namespace Microsoft.Tye.Hosting
                 UseProxy = false
             }));
 
-            var ingress = new List<Service>();
-
             foreach (var service in application.Services.Values)
             {
                 var serviceDescription = service.Description;

--- a/src/Microsoft.Tye.Hosting/Model/Application.cs
+++ b/src/Microsoft.Tye.Hosting/Model/Application.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Tye.Hosting.Model
 
         public Dictionary<string, Service> Services { get; }
 
+        public Dictionary<object, object> Items { get; } = new Dictionary<object, object>();
+
         public void PopulateEnvironment(Service service, Action<string, string> set, string defaultHost = "localhost")
         {
             if (service.Description.Configuration != null)
@@ -76,8 +78,9 @@ namespace Microsoft.Tye.Hosting.Model
                 throw new InvalidOperationException($"Unable to resolve the desired value '{source.Kind}' from binding '{source.Binding}' for service '{source.Service}'.");
             }
 
-            void SetBinding(string serviceName, ServiceBinding b)
+            void SetBinding(ServiceDescription service, ServiceBinding b)
             {
+                var serviceName = service.Name.ToUpper();
                 var configName = "";
                 var envName = "";
 
@@ -107,12 +110,17 @@ namespace Microsoft.Tye.Hosting.Model
 
                 if (b.Port != null)
                 {
-                    set($"SERVICE__{configName}__PORT", b.Port.Value.ToString());
-                    set($"{envName}_SERVICE_PORT", b.Port.Value.ToString());
+                    var port = (service.RunInfo is DockerRunInfo && service.Replicas == 1) ? b.ContainerPort ?? b.Port.Value : b.Port.Value;
+
+                    set($"SERVICE__{configName}__PORT", port.ToString());
+                    set($"{envName}_SERVICE_PORT", port.ToString());
                 }
 
-                set($"SERVICE__{configName}__HOST", b.Host ?? defaultHost);
-                set($"{envName}_SERVICE_HOST", b.Host ?? defaultHost);
+                // Use the container name as the host name if there's a single replica (current limitation)
+                var host = b.Host ?? (service.RunInfo is DockerRunInfo && service.Replicas == 1 ? service.Name : defaultHost);
+
+                set($"SERVICE__{configName}__HOST", host);
+                set($"{envName}_SERVICE_HOST", host);
             }
 
             // Inject dependency information
@@ -120,7 +128,7 @@ namespace Microsoft.Tye.Hosting.Model
             {
                 foreach (var b in s.Description.Bindings)
                 {
-                    SetBinding(s.Description.Name.ToUpper(), b);
+                    SetBinding(s.Description, b);
                 }
             }
         }

--- a/src/Microsoft.Tye.Hosting/Model/DockerStatus.cs
+++ b/src/Microsoft.Tye.Hosting/Model/DockerStatus.cs
@@ -12,6 +12,10 @@ namespace Microsoft.Tye.Hosting.Model
 
         public string? DockerCommand { get; set; }
 
+        public string? DockerNetwork { get; set; }
+
+        public string? DockerNetworkAlias { get; set; }
+
         public string? ContainerId { get; set; }
     }
 }

--- a/src/Microsoft.Tye.Hosting/Model/V1/V1ReplicaStatus.cs
+++ b/src/Microsoft.Tye.Hosting/Model/V1/V1ReplicaStatus.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Tye.Hosting.Model.V1
     {
         public string? DockerCommand { get; set; }
         public string? ContainerId { get; set; }
+        public string? DockerNetwork { get; set; }
+        public string? DockerNetworkAlias { get; set; }
         public string? Name { get; set; }
         public IEnumerable<int>? Ports { get; set; }
         public int? ExitCode { get; set; }

--- a/src/Microsoft.Tye.Hosting/PortAssigner.cs
+++ b/src/Microsoft.Tye.Hosting/PortAssigner.cs
@@ -84,14 +84,13 @@ namespace Microsoft.Tye.Hosting
                 // Default the first http and https port to 80 and 443
                 if (httpBinding != null)
                 {
-                    httpBinding.ContainerPort = 80;
+                    httpBinding.ContainerPort ??= 80;
                 }
 
                 if (httpsBinding != null)
                 {
-                    httpsBinding.ContainerPort = 443;
+                    httpsBinding.ContainerPort ??= 443;
                 }
-
             }
 
             return Task.CompletedTask;

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -129,6 +129,9 @@ namespace Microsoft.Tye.Hosting
                     // Default to development environment
                     ["DOTNET_ENVIRONMENT"] = "Development",
                     ["ASPNETCORE_ENVIRONMENT"] = "Development",
+                    // Remove the color codes from the console output
+                    ["DOTNET_LOGGING__CONSOLE__DISABLECOLORS"] = "true",
+                    ["ASPNETCORE_LOGGING__CONSOLE__DISABLECOLORS"] = "true"
                 };
 
                 // Set up environment variables to use the version of dotnet we're using to run

--- a/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
+++ b/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
@@ -185,6 +185,8 @@ namespace Microsoft.Tye.Hosting
                 {
                     replicaStatus.DockerCommand = dockerStatus.DockerCommand;
                     replicaStatus.ContainerId = dockerStatus.ContainerId;
+                    replicaStatus.DockerNetwork = dockerStatus.DockerNetwork;
+                    replicaStatus.DockerNetworkAlias = dockerStatus.DockerNetworkAlias;
                 }
             }
 

--- a/src/Microsoft.Tye.Hosting/TyeHost.cs
+++ b/src/Microsoft.Tye.Hosting/TyeHost.cs
@@ -70,14 +70,7 @@ namespace Microsoft.Tye.Hosting
             }
             finally
             {
-                try
-                {
-                    await StopAsync();
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error while shutting down");
-                }
+                await StopAsync();
             }
         }
 
@@ -289,6 +282,10 @@ namespace Microsoft.Tye.Hosting
                     await _processor.StopAsync(_application);
                 }
                 _processor = null;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error while shutting down");
             }
             finally
             {

--- a/src/tye/Program.RunCommand.cs
+++ b/src/tye/Program.RunCommand.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Tye
                     throw new CommandException($"No services found in \"{application.Source.Name}\"");
                 }
 
-                using var host = new TyeHost(application.ToHostingApplication(), args, debug);
+                await using var host = new TyeHost(application.ToHostingApplication(), args, debug);
                 await host.RunAsync();
             });
 

--- a/test/E2ETest/TestHelpers.cs
+++ b/test/E2ETest/TestHelpers.cs
@@ -109,11 +109,6 @@ namespace E2ETest
                     await startedTask.Task;
                 }
             }
-            catch (TaskCanceledException)
-            {
-                await host.StopAsync();
-                throw;
-            }
             finally
             {
                 foreach (var observer in servicesStateObserver)

--- a/test/E2ETest/TyePurgeTests.cs
+++ b/test/E2ETest/TyePurgeTests.cs
@@ -49,27 +49,22 @@ namespace E2ETest
             try
             {
                 await TestHelpers.StartHostAndWaitForReplicasToStart(host);
-                try
-                {
-                    var pids = GetAllAppPids(host.Application);
 
-                    Assert.True(Directory.Exists(tyeDir.FullName));
-                    Assert.Subset(new HashSet<int>(GetAllPids()), new HashSet<int>(pids));
+                var pids = GetAllAppPids(host.Application);
 
-                    await TestHelpers.PurgeHostAndWaitForGivenReplicasToStop(host,
-                        GetAllReplicasNames(host.Application));
+                Assert.True(Directory.Exists(tyeDir.FullName));
+                Assert.Subset(new HashSet<int>(GetAllPids()), new HashSet<int>(pids));
 
-                    var runningPids = new HashSet<int>(GetAllPids());
-                    Assert.True(pids.All(pid => !runningPids.Contains(pid)));
-                }
-                finally
-                {
-                    await host.StopAsync();
-                }
+                await TestHelpers.PurgeHostAndWaitForGivenReplicasToStop(host,
+                    GetAllReplicasNames(host.Application));
+
+                var runningPids = new HashSet<int>(GetAllPids());
+                Assert.True(pids.All(pid => !runningPids.Contains(pid)));
+
             }
             finally
             {
-                host.Dispose();
+                await host.DisposeAsync();
                 Assert.False(Directory.Exists(tyeDir.FullName));
             }
         }
@@ -94,33 +89,28 @@ namespace E2ETest
             try
             {
                 await TestHelpers.StartHostAndWaitForReplicasToStart(host);
-                try
-                {
-                    var pids = GetAllAppPids(host.Application);
-                    var containers = GetAllContainerIds(host.Application);
 
-                    Assert.True(Directory.Exists(tyeDir.FullName));
-                    Assert.Subset(new HashSet<int>(GetAllPids()), new HashSet<int>(pids));
-                    Assert.Subset(new HashSet<string>(await DockerAssert.GetRunningContainersIdsAsync(_output)),
-                        new HashSet<string>(containers));
+                var pids = GetAllAppPids(host.Application);
+                var containers = GetAllContainerIds(host.Application);
 
-                    await TestHelpers.PurgeHostAndWaitForGivenReplicasToStop(host,
-                        GetAllReplicasNames(host.Application));
+                Assert.True(Directory.Exists(tyeDir.FullName));
+                Assert.Subset(new HashSet<int>(GetAllPids()), new HashSet<int>(pids));
+                Assert.Subset(new HashSet<string>(await DockerAssert.GetRunningContainersIdsAsync(_output)),
+                    new HashSet<string>(containers));
 
-                    var runningPids = new HashSet<int>(GetAllPids());
-                    Assert.True(pids.All(pid => !runningPids.Contains(pid)));
-                    var runningContainers =
-                        new HashSet<string>(await DockerAssert.GetRunningContainersIdsAsync(_output));
-                    Assert.True(containers.All(c => !runningContainers.Contains(c)));
-                }
-                finally
-                {
-                    await host.StopAsync();
-                }
+                await TestHelpers.PurgeHostAndWaitForGivenReplicasToStop(host,
+                    GetAllReplicasNames(host.Application));
+
+                var runningPids = new HashSet<int>(GetAllPids());
+                Assert.True(pids.All(pid => !runningPids.Contains(pid)));
+                var runningContainers =
+                    new HashSet<string>(await DockerAssert.GetRunningContainersIdsAsync(_output));
+                Assert.True(containers.All(c => !runningContainers.Contains(c)));
+
             }
             finally
             {
-                host.Dispose();
+                await host.DisposeAsync();
                 Assert.False(Directory.Exists(tyeDir.FullName));
             }
         }

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -162,7 +162,6 @@ namespace E2ETest
             container.Bindings.AddRange(project.Bindings);
 
             await ProcessUtil.RunAsync("dotnet", $"publish \"{project.ProjectFile.FullName}\" /nologo", outputDataReceived: _sink.WriteLine, errorDataReceived: _sink.WriteLine);
-            
             application.Services.Add(container);
 
             var handler = new HttpClientHandler

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -95,11 +95,11 @@ namespace E2ETest
                 var frontendUri = await GetServiceUrl(client, uri, "frontend");
                 var backendUri = await GetServiceUrl(client, uri, "backend");
 
-                var frontendResponse = await client.GetAsync(frontendUri);
                 var backendResponse = await client.GetAsync(backendUri);
+                var frontendResponse = await client.GetAsync(frontendUri);
 
-                Assert.True(frontendResponse.IsSuccessStatusCode);
                 Assert.True(backendResponse.IsSuccessStatusCode);
+                Assert.True(frontendResponse.IsSuccessStatusCode);
             });
         }
 
@@ -131,11 +131,11 @@ namespace E2ETest
                 var frontendUri = await GetServiceUrl(client, uri, "frontend");
                 var backendUri = await GetServiceUrl(client, uri, "backend");
 
-                var frontendResponse = await client.GetAsync(frontendUri);
                 var backendResponse = await client.GetAsync(backendUri);
+                var frontendResponse = await client.GetAsync(frontendUri);
 
-                Assert.True(frontendResponse.IsSuccessStatusCode);
                 Assert.True(backendResponse.IsSuccessStatusCode);
+                Assert.True(frontendResponse.IsSuccessStatusCode);
             });
         }
 
@@ -177,11 +177,11 @@ namespace E2ETest
                 var frontendUri = await GetServiceUrl(client, uri, "frontend");
                 var backendUri = await GetServiceUrl(client, uri, "backend");
 
-                var frontendResponse = await client.GetAsync(frontendUri);
                 var backendResponse = await client.GetAsync(backendUri);
+                var frontendResponse = await client.GetAsync(frontendUri);
 
-                Assert.True(frontendResponse.IsSuccessStatusCode);
                 Assert.True(backendResponse.IsSuccessStatusCode);
+                Assert.True(frontendResponse.IsSuccessStatusCode);
             });
         }
 

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -11,7 +11,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.Tye;
-using Microsoft.Tye.ConfigModel;
 using Microsoft.Tye.Hosting;
 using Microsoft.Tye.Hosting.Model;
 using Microsoft.Tye.Hosting.Model.V1;
@@ -52,54 +51,23 @@ namespace E2ETest
             var projectFile = new FileInfo(Path.Combine(tempDirectory.DirectoryPath, "test-project.csproj"));
             var outputContext = new OutputContext(_sink, Verbosity.Debug);
             var application = await ApplicationFactory.CreateAsync(outputContext, projectFile);
-            using var host = new TyeHost(application.ToHostingApplication(), Array.Empty<string>())
+
+            var handler = new HttpClientHandler
             {
-                Sink = _sink,
+                ServerCertificateCustomValidationCallback = (a, b, c, d) => true,
+                AllowAutoRedirect = false
             };
 
-            await host.StartAsync();
-            try
+            var client = new HttpClient(new RetryHandler(handler));
+
+            await RunHostingApplication(application, Array.Empty<string>(), async (app, uri) =>
             {
-                var handler = new HttpClientHandler
-                {
-                    ServerCertificateCustomValidationCallback = (a, b, c, d) => true,
-                    AllowAutoRedirect = false
-                };
+                var testUri = await GetServiceUrl(client, uri, "test-project");
 
-                var client = new HttpClient(new RetryHandler(handler));
+                var testResponse = await client.GetAsync(testUri);
 
-                // Make sure dashboard and applications are up.
-                // Dashboard should be hosted in same process.
-                var dashboardUri = new Uri(host.DashboardWebApplication!.Addresses.First());
-                var dashboardString = await client.GetStringAsync($"{dashboardUri}api/v1/services/test-project");
-
-                var service = JsonSerializer.Deserialize<V1Service>(dashboardString, _options);
-                var binding = service.Description!.Bindings.Where(b => b.Protocol == "http").Single();
-                var uriBackendProcess = new Uri($"{binding.Protocol}://localhost:{binding.Port}");
-
-                // This isn't reliable right now because micronetes only guarantees the process starts, not that
-                // that kestrel started.
-                try
-                {
-                    var appResponse = await client.GetAsync(uriBackendProcess);
-                    Assert.Equal(HttpStatusCode.OK, appResponse.StatusCode);
-                }
-                finally
-                {
-                    // If we failed, there's a good chance the service isn't running. Let's get the logs either way and put
-                    // them in the output.
-                    var request = new HttpRequestMessage(HttpMethod.Get, new Uri(dashboardUri, $"/api/v1/logs/{service.Description.Name}"));
-                    var response = await client.SendAsync(request);
-                    var text = await response.Content.ReadAsStringAsync();
-
-                    _output.WriteLine($"Logs for service: {service.Description.Name}");
-                    _output.WriteLine(text);
-                }
-            }
-            finally
-            {
-                await host.StopAsync();
-            }
+                Assert.True(testResponse.IsSuccessStatusCode);
+            });
         }
 
         [Fact]
@@ -112,31 +80,62 @@ namespace E2ETest
             var projectFile = new FileInfo(Path.Combine(tempDirectory.DirectoryPath, "tye.yaml"));
             var outputContext = new OutputContext(_sink, Verbosity.Debug);
             var application = await ApplicationFactory.CreateAsync(outputContext, projectFile);
-            using var host = new TyeHost(application.ToHostingApplication(), Array.Empty<string>())
+
+            var handler = new HttpClientHandler
             {
-                Sink = _sink,
+                ServerCertificateCustomValidationCallback = (a, b, c, d) => true,
+                AllowAutoRedirect = false
             };
 
-            await host.StartAsync();
-            try
+            var client = new HttpClient(new RetryHandler(handler));
+
+            await RunHostingApplication(application, Array.Empty<string>(), async (app, uri) =>
             {
-                var handler = new HttpClientHandler
-                {
-                    ServerCertificateCustomValidationCallback = (a, b, c, d) => true,
-                    AllowAutoRedirect = false
-                };
+                var frontendUri = await GetServiceUrl(client, uri, "frontend");
+                var backendUri = await GetServiceUrl(client, uri, "backend");
 
-                var client = new HttpClient(new RetryHandler(handler));
+                var frontendResponse = await client.GetAsync(frontendUri);
+                var backendResponse = await client.GetAsync(backendUri);
 
-                var dashboardUri = new Uri(host.DashboardWebApplication!.Addresses.First());
+                Assert.True(frontendResponse.IsSuccessStatusCode);
+                Assert.True(backendResponse.IsSuccessStatusCode);
+            });
+        }
 
-                await CheckServiceIsUp(host.Application, client, "backend", dashboardUri);
-                await CheckServiceIsUp(host.Application, client, "frontend", dashboardUri);
-            }
-            finally
+        [ConditionalFact]
+        [SkipIfDockerNotRunning]
+        public async Task FrontendBackendRunTestWithDocker()
+        {
+            var projectDirectory = new DirectoryInfo(Path.Combine(TestHelpers.GetSolutionRootDirectory("tye"), "samples", "frontend-backend"));
+            using var tempDirectory = TempDirectory.Create(preferUserDirectoryOnMacOS: true);
+            DirectoryCopy.Copy(projectDirectory.FullName, tempDirectory.DirectoryPath);
+
+            var projectFile = new FileInfo(Path.Combine(tempDirectory.DirectoryPath, "tye.yaml"));
+            var outputContext = new OutputContext(_sink, Verbosity.Debug);
+            var application = await ApplicationFactory.CreateAsync(outputContext, projectFile);
+
+            var handler = new HttpClientHandler
             {
-                await host.StopAsync();
-            }
+                ServerCertificateCustomValidationCallback = (a, b, c, d) => true,
+                AllowAutoRedirect = false
+            };
+
+            var client = new HttpClient(new RetryHandler(handler));
+
+            await RunHostingApplication(application, new[] { "--docker" }, async (app, uri) =>
+            {
+                // Make sure we're running containers
+                Assert.True(app.Services.All(s => s.Value.Description.RunInfo is DockerRunInfo));
+
+                var frontendUri = await GetServiceUrl(client, uri, "frontend");
+                var backendUri = await GetServiceUrl(client, uri, "backend");
+
+                var frontendResponse = await client.GetAsync(frontendUri);
+                var backendResponse = await client.GetAsync(backendUri);
+
+                Assert.True(frontendResponse.IsSuccessStatusCode);
+                Assert.True(backendResponse.IsSuccessStatusCode);
+            });
         }
 
         [ConditionalFact]
@@ -165,7 +164,7 @@ namespace E2ETest
             var client = new HttpClient(new RetryHandler(handler));
             var args = new[] { "--docker" };
 
-            await RunHostingApplication(application, args, _sink, async serviceApi =>
+            await RunHostingApplication(application, args, async (app, serviceApi) =>
             {
                 var serviceUri = await GetServiceUrl(client, serviceApi, "volume-test");
 
@@ -180,7 +179,7 @@ namespace E2ETest
                 Assert.Equal("Things saved to the volume!", await client.GetStringAsync(serviceUri));
             });
 
-            await RunHostingApplication(application, args, _sink, async serviceApi =>
+            await RunHostingApplication(application, args, async (app, serviceApi) =>
             {
                 var serviceUri = await GetServiceUrl(client, serviceApi, "volume-test");
 
@@ -223,7 +222,7 @@ namespace E2ETest
             var client = new HttpClient(new RetryHandler(handler));
             var args = new[] { "--docker" };
 
-            await RunHostingApplication(application, args, _sink, async serviceApi =>
+            await RunHostingApplication(application, args, async (app, serviceApi) =>
             {
                 var serviceUri = await GetServiceUrl(client, serviceApi, "volume-test");
 
@@ -244,10 +243,6 @@ namespace E2ETest
             var projectFile = new FileInfo(Path.Combine(tempDirectory.DirectoryPath, "tye.yaml"));
             var outputContext = new OutputContext(_sink, Verbosity.Debug);
             var application = await ApplicationFactory.CreateAsync(outputContext, projectFile);
-            using var host = new TyeHost(application.ToHostingApplication(), Array.Empty<string>())
-            {
-                Sink = _sink,
-            };
 
             var handler = new HttpClientHandler
             {
@@ -255,13 +250,13 @@ namespace E2ETest
                 AllowAutoRedirect = false
             };
 
-            using var client = new HttpClient(new RetryHandler(handler));
-            await host.StartAsync();
-            var serviceApi = new Uri(host.DashboardWebApplication!.Addresses.First());
+            var client = new HttpClient(new RetryHandler(handler));
 
-            try
+            await RunHostingApplication(application, Array.Empty<string>(), async (app, uri) =>
             {
-                var ingressUri = await GetServiceUrl(client, serviceApi, "ingress");
+                using var client = new HttpClient();
+
+                var ingressUri = await GetServiceUrl(client, uri, "ingress");
 
                 var responseA = await client.GetAsync(ingressUri + "/A");
                 var responseB = await client.GetAsync(ingressUri + "/B");
@@ -279,64 +274,7 @@ namespace E2ETest
 
                 Assert.StartsWith("Hello from Application A", await responseA.Content.ReadAsStringAsync());
                 Assert.StartsWith("Hello from Application B", await responseB.Content.ReadAsStringAsync());
-            }
-            finally
-            {
-                // If we failed, there's a good chance the service isn't running. Let's get the logs either way and put
-                // them in the output.
-                foreach (var s in host.Application.Services.Values)
-                {
-                    var request = new HttpRequestMessage(HttpMethod.Get, new Uri(serviceApi, $"/api/v1/logs/{s.Description.Name}"));
-                    var response = await client.SendAsync(request);
-                    var text = await response.Content.ReadAsStringAsync();
-
-                    _output.WriteLine($"Logs for service: {s.Description.Name}");
-                    _output.WriteLine(text);
-                }
-
-                await host.StopAsync();
-            }
-        }
-
-        [ConditionalFact]
-        [SkipIfDockerNotRunning]
-        public async Task FrontendBackendRunTestWithDocker()
-        {
-            var projectDirectory = new DirectoryInfo(Path.Combine(TestHelpers.GetSolutionRootDirectory("tye"), "samples", "frontend-backend"));
-            using var tempDirectory = TempDirectory.Create(preferUserDirectoryOnMacOS: true);
-            DirectoryCopy.Copy(projectDirectory.FullName, tempDirectory.DirectoryPath);
-
-            var projectFile = new FileInfo(Path.Combine(tempDirectory.DirectoryPath, "tye.yaml"));
-            var outputContext = new OutputContext(_sink, Verbosity.Debug);
-            var application = await ApplicationFactory.CreateAsync(outputContext, projectFile);
-            using var host = new TyeHost(application.ToHostingApplication(), new[] { "--docker" })
-            {
-                Sink = _sink,
-            };
-
-            await host.StartAsync();
-            try
-            {
-                // Make sure we're running containers
-                Assert.True(host.Application.Services.All(s => s.Value.Description.RunInfo is DockerRunInfo));
-
-                var handler = new HttpClientHandler
-                {
-                    ServerCertificateCustomValidationCallback = (a, b, c, d) => true,
-                    AllowAutoRedirect = false
-                };
-
-                var client = new HttpClient(new RetryHandler(handler));
-
-                var dashboardUri = new Uri(host.DashboardWebApplication!.Addresses.First());
-
-                await CheckServiceIsUp(host.Application, client, "backend", dashboardUri, timeout: TimeSpan.FromSeconds(60));
-                await CheckServiceIsUp(host.Application, client, "frontend", dashboardUri, timeout: TimeSpan.FromSeconds(60));
-            }
-            finally
-            {
-                await host.StopAsync();
-            }
+            });
         }
 
         [Fact]
@@ -351,109 +289,54 @@ namespace E2ETest
             // Debug targets can be null if not specified, so make sure calling host.Start does not throw.
             var outputContext = new OutputContext(_sink, Verbosity.Debug);
             var application = await ApplicationFactory.CreateAsync(outputContext, projectFile);
-            using var host = new TyeHost(application.ToHostingApplication(), Array.Empty<string>())
+            await using var host = new TyeHost(application.ToHostingApplication(), Array.Empty<string>())
             {
                 Sink = _sink,
             };
 
             await host.StartAsync();
-
-            await host.StopAsync();
         }
 
-        private async Task<string> GetServiceUrl(HttpClient client, Uri serviceApi, string serviceName)
+        private async Task<string> GetServiceUrl(HttpClient client, Uri uri, string serviceName)
         {
-            var serviceResult = await client.GetStringAsync($"{serviceApi}api/v1/services/{serviceName}");
+            var serviceResult = await client.GetStringAsync($"{uri}api/v1/services/{serviceName}");
             var service = JsonSerializer.Deserialize<V1Service>(serviceResult, _options);
             var binding = service.Description!.Bindings.Where(b => b.Protocol == "http").Single();
             return $"{binding.Protocol ?? "http"}://localhost:{binding.Port}";
         }
 
-        private async Task RunHostingApplication(ApplicationBuilder application, string[] args, TestOutputLogEventSink sink, Func<Uri, Task> execute)
+        private async Task RunHostingApplication(ApplicationBuilder application, string[] args, Func<Application, Uri, Task> execute)
         {
-            using var host = new TyeHost(application.ToHostingApplication(), args)
+            await using var host = new TyeHost(application.ToHostingApplication(), args)
             {
-                Sink = sink,
+                Sink = _sink,
             };
-
-            await StartHostAndWaitForReplicasToStart(host);
-
-            var serviceApi = new Uri(host.DashboardWebApplication!.Addresses.First());
 
             try
             {
-                await execute(serviceApi!);
+                await StartHostAndWaitForReplicasToStart(host);
+
+                var uri = new Uri(host.DashboardWebApplication!.Addresses.First());
+
+                await execute(host.Application, uri!);
             }
             finally
             {
-                using (var client = new HttpClient())
+                if (host.DashboardWebApplication != null)
                 {
-                    // If we failed, there's a good chance the service isn't running. Let's get the logs either way and put
-                    // them in the output.
+                    var uri = new Uri(host.DashboardWebApplication!.Addresses.First());
+
+                    using var client = new HttpClient();
+
                     foreach (var s in host.Application.Services.Values)
                     {
-                        var request = new HttpRequestMessage(HttpMethod.Get, new Uri(serviceApi, $"/api/v1/logs/{s.Description.Name}"));
+                        var request = new HttpRequestMessage(HttpMethod.Get, new Uri(uri, $"/api/v1/logs/{s.Description.Name}"));
                         var response = await client.SendAsync(request);
                         var text = await response.Content.ReadAsStringAsync();
 
                         _output.WriteLine($"Logs for service: {s.Description.Name}");
                         _output.WriteLine(text);
                     }
-                }
-
-                await host.StopAsync();
-            }
-        }
-
-        private async Task CheckServiceIsUp(Application application, HttpClient client, string serviceName, Uri dashboardUri, TimeSpan? timeout = default)
-        {
-            // make sure backend is up before frontend
-            var dashboardString = await client.GetStringAsync($"{dashboardUri}api/v1/services/{serviceName}");
-
-            var service = JsonSerializer.Deserialize<V1Service>(dashboardString, _options);
-            var binding = service.Description!.Bindings.Where(b => b.Protocol == "http").Single();
-            var uriBackendProcess = new Uri($"{binding.Protocol}://localhost:{binding.Port}");
-
-            var startTime = DateTime.UtcNow;
-            try
-            {
-                // Wait up until the timeout to see if we can access the service.
-                // For instance if we have to pull a base-image it can take a while.
-                while (timeout.HasValue && startTime + timeout.Value > DateTime.UtcNow)
-                {
-                    try
-                    {
-                        await client.GetAsync(uriBackendProcess);
-                        break;
-                    }
-                    catch (HttpRequestException)
-                    {
-                        await Task.Delay(TimeSpan.FromSeconds(3));
-                    }
-                }
-
-                var appResponse = await client.GetAsync(uriBackendProcess);
-                var content = await appResponse.Content.ReadAsStringAsync();
-                _output.WriteLine(content);
-                Assert.Equal(HttpStatusCode.OK, appResponse.StatusCode);
-                if (serviceName == "frontend")
-                {
-                    Assert.Matches("Frontend Listening IP: (.+)\n", content);
-                    Assert.Matches("Backend Listening IP: (.+)\n", content);
-                }
-            }
-            finally
-            {
-                // If we failed, there's a good chance the service isn't running. Let's get the logs either way and put
-                // them in the output.
-                foreach (var s in application.Services.Values)
-                {
-                    var request = new HttpRequestMessage(HttpMethod.Get, new Uri(dashboardUri, $"/api/v1/logs/{s.Description.Name}"));
-                    var response = await client.SendAsync(request);
-                    var text = await response.Content.ReadAsStringAsync();
-
-                    _output.WriteLine($"Logs for service: {s.Description.Name}");
-                    _output.WriteLine(text);
                 }
             }
         }

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -377,12 +377,15 @@ namespace E2ETest
 
                     foreach (var s in host.Application.Services.Values)
                     {
-                        var request = new HttpRequestMessage(HttpMethod.Get, new Uri(uri, $"/api/v1/logs/{s.Description.Name}"));
-                        var response = await client.SendAsync(request);
-                        var text = await response.Content.ReadAsStringAsync();
+                        var logs = await client.GetStringAsync(new Uri(uri, $"/api/v1/logs/{s.Description.Name}"));
 
                         _output.WriteLine($"Logs for service: {s.Description.Name}");
-                        _output.WriteLine(text);
+                        _output.WriteLine(logs);
+
+                        var description = await client.GetStringAsync(new Uri(uri, $"/api/v1/services/{s.Description.Name}"));
+
+                        _output.WriteLine($"Service defintion: {s.Description.Name}");
+                        _output.WriteLine(description);
                     }
                 }
             }


### PR DESCRIPTION
- This adds all containers in the tye.yaml to the same container network.
- Container networking only works with a single replica today since the containers are named after their replicas.
- Use the container host name and port when injecting env variables. This handles the multiple replica case by falling back to the host ip and port.
- This cleans up container to container communication when migrating docker-compose files.
- Don't override the container port if already set.
- Remove StopAsync from TyeHost and exposed DisposeAsync. This patterns removes common clean up and hanging issues that occur when errors happen on start/stop
- Cleaned up run tests to use similar code to run, clean up and capture logs.