### PR TITLE
Pass working directory to dotnet build

### DIFF
--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Tye.Hosting
 
                 service.Logs.OnNext($"dotnet build \"{service.Status.ProjectFilePath}\" /nologo");
 
-                var buildResult = await ProcessUtil.RunAsync("dotnet", $"build \"{service.Status.ProjectFilePath}\" /nologo", throwOnError: false);
+                var buildResult = await ProcessUtil.RunAsync("dotnet", $"build \"{service.Status.ProjectFilePath}\" /nologo", throwOnError: false, workingDirectory: workingDirectory);
 
                 service.Logs.OnNext(buildResult.StandardOutput);
 


### PR DESCRIPTION
This PR adds passing of the project's directory to `dotnet build`.

This is required e.g. if the project contains a `global.json` file.