### PR TITLE
We get proxying for free within the container

### DIFF
--- a/samples/frontend-backend/frontend/ConfigurationExtensions.cs
+++ b/samples/frontend-backend/frontend/ConfigurationExtensions.cs
@@ -8,6 +8,11 @@ namespace Microsoft.Extensions.Configuration
 {
     public static class ConfigurationExtensions
     {
+        public static string? GetServiceHost(this IConfiguration configuration, string name)
+        {
+            return configuration[$"service:{name}:host"];
+        }
+
         public static Uri? GetServiceUri(this IConfiguration configuration, string name)
         {
             var host = configuration[$"service:{name}:host"];

--- a/samples/frontend-backend/frontend/Startup.cs
+++ b/samples/frontend-backend/frontend/Startup.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
@@ -57,12 +58,17 @@ namespace Frontend
                     var bytes = await httpClient.GetByteArrayAsync("/");
                     var backendInfo = JsonSerializer.Deserialize<BackendInfo>(bytes, options);
 
+                    var backendHost = Configuration.GetServiceHost("backend");
+                    var addresses = await Dns.GetHostAddressesAsync(backendHost);
+
                     await context.Response.WriteAsync($"Frontend Listening IP: {context.Connection.LocalIpAddress}{Environment.NewLine}");
                     await context.Response.WriteAsync($"Frontend Hostname: {Dns.GetHostName()}{Environment.NewLine}");
                     await context.Response.WriteAsync($"EnvVar Configuration value: {Configuration["App:Value"]}{Environment.NewLine}");
 
                     await context.Response.WriteAsync($"Backend Listening IP: {backendInfo.IP}{Environment.NewLine}");
                     await context.Response.WriteAsync($"Backend Hostname: {backendInfo.Hostname}{Environment.NewLine}");
+
+                    await context.Response.WriteAsync($"Backend Host Addresses: {string.Join(", ", addresses.Select(a => a.ToString()))}");
                 });
 
                 endpoints.MapHealthChecks("/healthz");

--- a/src/Microsoft.Tye.Hosting/DockerRunner.cs
+++ b/src/Microsoft.Tye.Hosting/DockerRunner.cs
@@ -213,7 +213,8 @@ namespace Microsoft.Tye.Hosting
                 }
 
                 var command = $"run -d {workingDirectory} {volumes} {environmentArguments} {portString} --name {replica} --restart=unless-stopped {docker.Image} {docker.Args ?? ""}";
-                _logger.LogInformation("Running docker command {Command}", command);
+
+                _logger.LogInformation("Running command image {Image} for {Replica}", docker.Image, replica);
 
                 service.Logs.OnNext($"[{replica}]: docker {command}");
 
@@ -259,12 +260,9 @@ namespace Microsoft.Tye.Hosting
 
                 if (!string.IsNullOrEmpty(dockerNetwork))
                 {
-                    // If this is the only replica then the network alias is the service name
-                    var alias = serviceDescription.Replicas == 1 ? serviceDescription.Name : replica;
+                    status.DockerNetworkAlias = serviceDescription.Name;
 
-                    status.DockerNetworkAlias = alias;
-
-                    var networkCommand = $"network connect {dockerNetwork} {replica} --alias {alias}";
+                    var networkCommand = $"network connect {dockerNetwork} {replica} --alias {serviceDescription.Name}";
 
                     service.Logs.OnNext($"[{replica}]: docker {networkCommand}");
 

--- a/src/Microsoft.Tye.Hosting/Model/Application.cs
+++ b/src/Microsoft.Tye.Hosting/Model/Application.cs
@@ -111,8 +111,7 @@ namespace Microsoft.Tye.Hosting.Model
                 if (b.Port != null)
                 {
                     var port = (service.Description.RunInfo is DockerRunInfo &&
-                                targetService.RunInfo is DockerRunInfo &&
-                                targetService.Replicas == 1) ? b.ContainerPort ?? b.Port.Value : b.Port.Value;
+                                targetService.RunInfo is DockerRunInfo) ? b.ContainerPort ?? b.Port.Value : b.Port.Value;
 
                     set($"SERVICE__{configName}__PORT", port.ToString());
                     set($"{envName}_SERVICE_PORT", port.ToString());
@@ -120,8 +119,7 @@ namespace Microsoft.Tye.Hosting.Model
 
                 // Use the container name as the host name if there's a single replica (current limitation)
                 var host = b.Host ?? (service.Description.RunInfo is DockerRunInfo &&
-                                      targetService.RunInfo is DockerRunInfo &&
-                                      targetService.Replicas == 1 ? targetService.Name : defaultHost);
+                                      targetService.RunInfo is DockerRunInfo ? targetService.Name : defaultHost);
 
                 set($"SERVICE__{configName}__HOST", host);
                 set($"{envName}_SERVICE_HOST", host);


### PR DESCRIPTION
- Turns out the same alias works fine and docker will
associate multiple IPs with a single alias
- Remove the docker run command from the output and leave it in the log
- Dump out the backend host names in the frontend backend example

Log clean up:

![image](https://user-images.githubusercontent.com/95136/78179265-c9fa9800-7415-11ea-8187-51cfd9801876.png)
