### PR TITLE
Add debug and tracing annotations

### DIFF
--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -138,19 +138,14 @@ namespace Microsoft.Tye.Extensions.Dapr
                         deployment.Annotations.Add("dapr.io/id", project.Name);
                         deployment.Annotations.Add("dapr.io/port", (httpBinding.Port ?? 80).ToString(CultureInfo.InvariantCulture));
 
-                        if (!config.Data.Any())
+                        if (config.Data.TryGetValue("config", out var daprConfig) && daprConfig is object)
                         {
-                            continue;
+                            deployment.Annotations.TryAdd("dapr.io/config", daprConfig.ToString());
                         }
 
-                        if (config.Data.TryGetValue("config", out var daprConfig))
+                        if (config.Data.TryGetValue("log-level", out var logLevel) && logLevel is object)
                         {
-                            deployment.Annotations.Add("dapr.io/config", (daprConfig.ToString() ?? "tracing").ToString(CultureInfo.InvariantCulture));
-                        }
-
-                        if (config.Data.TryGetValue("log-level", out var logLevel))
-                        {
-                            deployment.Annotations.Add("dapr.io/log-level", (logLevel.ToString() ?? "info").ToString(CultureInfo.InvariantCulture));
+                            deployment.Annotations.TryAdd("dapr.io/log-level", logLevel.ToString());
                         }
                     }
                 }

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Tye.Extensions.Dapr
 
                         // These environment variables are replaced with environment variables
                         // defined for this service.
-                        Args = $"-app-id {project.Name} -app-port %APP_PORT% -dapr-grpc-port %DAPR_GRPC_PORT% --dapr-http-port %DAPR_HTTP_PORT% --metrics-port %METRICS_PORT% --placement-address localhost:50005",
+                        Args = $"-app-id {project.Name} -app-port %APP_PORT% -dapr-grpc-port %DAPR_GRPC_PORT% --dapr-http-port %DAPR_HTTP_PORT% --metrics-port %METRICS_PORT% -log-level %LOG_LEVEL% -config %CONFIG% --placement-address localhost:50005",
                     };
                     context.Application.Services.Add(proxy);
 
@@ -138,17 +138,15 @@ namespace Microsoft.Tye.Extensions.Dapr
                         deployment.Annotations.Add("dapr.io/id", project.Name);
                         deployment.Annotations.Add("dapr.io/port", (httpBinding.Port ?? 80).ToString(CultureInfo.InvariantCulture));
 
-#pragma warning disable CS8604 // Possible null reference argument.
                         if (config.Data.TryGetValue("config", out var daprConfig) && daprConfig is object)
                         {
-                            deployment.Annotations.TryAdd("dapr.io/config", daprConfig.ToString());
+                            deployment.Annotations.TryAdd("dapr.io/config", daprConfig!.ToString());
                         }
 
                         if (config.Data.TryGetValue("log-level", out var logLevel) && logLevel is object)
                         {
-                            deployment.Annotations.TryAdd("dapr.io/log-level", logLevel.ToString());
+                            deployment.Annotations.TryAdd("dapr.io/log-level", logLevel!.ToString());
                         }
-#pragma warning restore CS8604 // Possible null reference argument.
                     }
                 }
             }

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -138,15 +138,17 @@ namespace Microsoft.Tye.Extensions.Dapr
                         deployment.Annotations.Add("dapr.io/id", project.Name);
                         deployment.Annotations.Add("dapr.io/port", (httpBinding.Port ?? 80).ToString(CultureInfo.InvariantCulture));
 
+#nullable disable
                         if (config.Data.TryGetValue("config", out var daprConfig) && daprConfig is object)
                         {
                             deployment.Annotations.TryAdd("dapr.io/config", daprConfig!.ToString());
                         }
 
-                        if (config.Data.TryGetValue("log-level", out var logLevel) && logLevel is object)
+                        if (config.Data.TryGetValue("log-level",  out var logLevel) && logLevel is object)
                         {
                             deployment.Annotations.TryAdd("dapr.io/log-level", logLevel!.ToString());
                         }
+#nullable enable
                     }
                 }
             }

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -143,14 +143,14 @@ namespace Microsoft.Tye.Extensions.Dapr
                             continue;
                         }
 
-                        if (config.Data.ContainsKey("config"))
+                        if (config.Data.TryGetValue("config", out var daprConfig))
                         {
-                            deployment.Annotations.Add("dapr.io/config", (config.Data["config"] ?? "tracing").ToString());
+                            deployment.Annotations.Add("dapr.io/config", (daprConfig.ToString() ?? "tracing").ToString(CultureInfo.InvariantCulture));
                         }
 
-                        if (config.Data.ContainsKey("log-level"))
+                        if (config.Data.TryGetValue("log-level", out var logLevel))
                         {
-                            deployment.Annotations.Add("dapr.io/log-level", (config.Data["log-level"] ?? "info").ToString());
+                            deployment.Annotations.Add("dapr.io/log-level", (logLevel.ToString() ?? "info").ToString(CultureInfo.InvariantCulture));
                         }
                     }
                 }

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -138,17 +138,15 @@ namespace Microsoft.Tye.Extensions.Dapr
                         deployment.Annotations.Add("dapr.io/id", project.Name);
                         deployment.Annotations.Add("dapr.io/port", (httpBinding.Port ?? 80).ToString(CultureInfo.InvariantCulture));
 
-#nullable disable
                         if (config.Data.TryGetValue("config", out var daprConfig) && daprConfig is object)
                         {
-                            deployment.Annotations.TryAdd("dapr.io/config", daprConfig!.ToString());
+                            deployment.Annotations.TryAdd("dapr.io/config", daprConfig!.ToString() ?? string.Empty);
                         }
 
                         if (config.Data.TryGetValue("log-level",  out var logLevel) && logLevel is object)
                         {
-                            deployment.Annotations.TryAdd("dapr.io/log-level", logLevel!.ToString());
+                            deployment.Annotations.TryAdd("dapr.io/log-level", logLevel!.ToString() ?? string.Empty);
                         }
-#nullable enable
                     }
                 }
             }

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -138,15 +138,17 @@ namespace Microsoft.Tye.Extensions.Dapr
                         deployment.Annotations.Add("dapr.io/id", project.Name);
                         deployment.Annotations.Add("dapr.io/port", (httpBinding.Port ?? 80).ToString(CultureInfo.InvariantCulture));
 
+#pragma warning disable CS8604 // Possible null reference argument.
                         if (config.Data.TryGetValue("config", out var daprConfig) && daprConfig is object)
                         {
-                            deployment.Annotations.TryAdd("dapr.io/config", daprConfig?.ToString());
+                            deployment.Annotations.TryAdd("dapr.io/config", daprConfig.ToString());
                         }
 
                         if (config.Data.TryGetValue("log-level", out var logLevel) && logLevel is object)
                         {
-                            deployment.Annotations.TryAdd("dapr.io/log-level", logLevel?.ToString());
+                            deployment.Annotations.TryAdd("dapr.io/log-level", logLevel.ToString());
                         }
+#pragma warning restore CS8604 // Possible null reference argument.
                     }
                 }
             }

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -137,6 +137,21 @@ namespace Microsoft.Tye.Extensions.Dapr
                         deployment.Annotations.Add("dapr.io/enabled", "true");
                         deployment.Annotations.Add("dapr.io/id", project.Name);
                         deployment.Annotations.Add("dapr.io/port", (httpBinding.Port ?? 80).ToString(CultureInfo.InvariantCulture));
+
+                        if (!config.Data.Any())
+                        {
+                            continue;
+                        }
+
+                        if (config.Data.ContainsKey("config"))
+                        {
+                            deployment.Annotations.Add("dapr.io/config", (config.Data["config"] ?? "tracing").ToString());
+                        }
+
+                        if (config.Data.ContainsKey("log-level"))
+                        {
+                            deployment.Annotations.Add("dapr.io/log-level", (config.Data["log-level"] ?? "info").ToString());
+                        }
                     }
                 }
             }

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -140,12 +140,12 @@ namespace Microsoft.Tye.Extensions.Dapr
 
                         if (config.Data.TryGetValue("config", out var daprConfig) && daprConfig is object)
                         {
-                            deployment.Annotations.TryAdd("dapr.io/config", daprConfig.ToString());
+                            deployment.Annotations.TryAdd("dapr.io/config", daprConfig?.ToString());
                         }
 
                         if (config.Data.TryGetValue("log-level", out var logLevel) && logLevel is object)
                         {
-                            deployment.Annotations.TryAdd("dapr.io/log-level", logLevel.ToString());
+                            deployment.Annotations.TryAdd("dapr.io/log-level", logLevel?.ToString());
                         }
                     }
                 }

--- a/test/E2ETest/testassets/generate/dapr.yaml
+++ b/test/E2ETest/testassets/generate/dapr.yaml
@@ -6,6 +6,8 @@ metadata:
     dapr.io/enabled: 'true'
     dapr.io/id: 'dapr_test_project'
     dapr.io/port: '80'
+    dapr.io/config: 'tracing'
+    dapr.io/log-level: 'debug'
   labels:
     app.kubernetes.io/name: 'dapr_test_project'
     app.kubernetes.io/part-of: 'dapr_test_application'
@@ -20,6 +22,8 @@ spec:
         dapr.io/enabled: 'true'
         dapr.io/id: 'dapr_test_project'
         dapr.io/port: '80'
+        dapr.io/config: 'tracing'
+        dapr.io/log-level: 'debug'
       labels:
         app.kubernetes.io/name: 'dapr_test_project'
         app.kubernetes.io/part-of: 'dapr_test_application'

--- a/test/E2ETest/testassets/projects/dapr/tye.yaml
+++ b/test/E2ETest/testassets/projects/dapr/tye.yaml
@@ -1,6 +1,8 @@
 name: dapr_test_application
 extensions:
 - name: dapr
+  config: tracing
+  log-level: debug
 services:
 - name: dapr_test_project
   project: dapr.csproj


### PR DESCRIPTION
This PR adds `dapr.io/config` and `dapr.io/log-level` into the annotations section in dapr.yaml. Related to https://github.com/dotnet/tye/issues/296