### PR TITLE
Add 'dev-tye' func to `activate` scripts to improve local dev flow

### DIFF
--- a/activate.ps1
+++ b/activate.ps1
@@ -11,6 +11,11 @@ if ($MyInvocation.CommandOrigin -eq 'runspace') {
     exit 1
 }
 
+function dev-tye() {
+    $ProjectPath = Join-Path (Join-Path $PSScriptRoot "src") "tye"
+    dotnet run --project "$ProjectPath" @args
+}
+
 function deactivate ([switch]$init) {
 
     # reset old environment variables

--- a/activate.ps1
+++ b/activate.ps1
@@ -32,8 +32,9 @@ function deactivate ([switch]$init) {
     Remove-Item env:DOTNET_ROOT -ea ignore
     Remove-Item env:DOTNET_MULTILEVEL_LOOKUP -ea ignore
     if (-not $init) {
-        # Remove the deactivate function
+        # Remove the deactivate and dev-tye functions
         Remove-Item function:deactivate
+        Remove-Item function:dev-tye
     }
 }
 

--- a/activate.ps1
+++ b/activate.ps1
@@ -11,7 +11,7 @@ if ($MyInvocation.CommandOrigin -eq 'runspace') {
     exit 1
 }
 
-function dev-tye() {
+function tye() {
     $ProjectPath = Join-Path (Join-Path $PSScriptRoot "src") "tye"
     dotnet run --project "$ProjectPath" @args
 }
@@ -34,7 +34,7 @@ function deactivate ([switch]$init) {
     if (-not $init) {
         # Remove the deactivate and dev-tye functions
         Remove-Item function:deactivate
-        Remove-Item function:dev-tye
+        Remove-Item function:tye
     }
 }
 

--- a/activate.sh
+++ b/activate.sh
@@ -61,6 +61,7 @@ deactivate () {
     if [ ! "${1:-}" = "init" ] ; then
         # Remove the deactivate function
         unset -f deactivate
+        unset -f dev-tye
     fi
 }
 

--- a/activate.sh
+++ b/activate.sh
@@ -32,6 +32,10 @@ if [ $sourced -eq 0 ]; then
     exit 1
 fi
 
+dev-tye () {
+    dotnet run --project "$THIS_SCRIPT/src/tye" "$@"
+}
+
 deactivate () {
 
     # reset old environment variables

--- a/activate.sh
+++ b/activate.sh
@@ -32,7 +32,7 @@ if [ $sourced -eq 0 ]; then
     exit 1
 fi
 
-dev-tye () {
+tye () {
     dotnet run --project "$THIS_SCRIPT/src/tye" "$@"
 }
 
@@ -61,7 +61,7 @@ deactivate () {
     if [ ! "${1:-}" = "init" ] ; then
         # Remove the deactivate function
         unset -f deactivate
-        unset -f dev-tye
+        unset -f tye
     fi
 }
 


### PR DESCRIPTION
So the idea here is that running `. .\activate.ps1` will also add a `dev-tye` function that automatically runs the `src\tye\tye.csproj` from the clone in which you ran `activate`. Because it's a global func, it works wherever you are. Running the `deactivate` function removes the `dev-tye` function.

Might be related to #262 ? @davidfowl had some comments there that seemed to be looking for more complicated stuff, but this seemed like something useful to me and might be nice for other folks in the repo.

I'm happy to just have this in my own scripts if people don't think this fits in the main `activate` script, or should be somewhere else. Just sketched it out while doing some exploration in teh repo and though it could be c o o l.