### PR TITLE
Exclude projects without launchSettings.json

### DIFF
--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigFactory.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigFactory.cs
@@ -61,13 +61,23 @@ namespace Microsoft.Tye.ConfigModel
             // throughout the code, because we load them dynamically.
             foreach (var projectFile in ProjectReader.EnumerateProjects(file))
             {
-                var service = new ConfigService()
+                // Check for the existance of a launchSettings.json as an indication that the project is
+                // runnable. This will only apply in the case where tye is being used against a solution
+                // like `tye init` or `tye run` without a `tye.yaml`.
+                //
+                // We want a *fast* heuristic that excludes unit test projects and class libraries without
+                // having to load all of the projects. 
+                var launchSettings = Path.Combine(projectFile.DirectoryName, "Properties", "launchSettings.json");
+                if (File.Exists(launchSettings))
                 {
-                    Name = Path.GetFileNameWithoutExtension(projectFile.Name).ToLowerInvariant(),
-                    Project = projectFile.FullName.Replace('\\', '/'),
-                };
+                    var service = new ConfigService()
+                    {
+                        Name = Path.GetFileNameWithoutExtension(projectFile.Name).ToLowerInvariant(),
+                        Project = projectFile.FullName.Replace('\\', '/'),
+                    };
 
-                application.Services.Add(service);
+                    application.Services.Add(service);
+                }
             }
 
             return application;

--- a/test/E2ETest/TyeInitTests.cs
+++ b/test/E2ETest/TyeInitTests.cs
@@ -74,5 +74,24 @@ namespace E2ETest
 
             Assert.Equal(expectedContent.NormalizeNewLines(), content.NormalizeNewLines());
         }
+
+        // Tests our logic that excludes non-applications (unit tests, classlibs, etc)
+        [Fact]
+        public void Init_ProjectKinds()
+        {
+            using var projectDirectory = CopyTestProjectDirectory("project-types");
+
+            // delete already present yaml
+            File.Delete(Path.Combine(projectDirectory.DirectoryPath, "tye.yaml"));
+
+            var projectFile = new FileInfo(Path.Combine(projectDirectory.DirectoryPath, "project-types.sln"));
+
+            var (content, _) = InitHost.CreateTyeFileContent(projectFile, force: false);
+            var expectedContent = File.ReadAllText("testassets/init/project-types.yaml");
+
+            output.WriteLine(content);
+
+            Assert.Equal(expectedContent.NormalizeNewLines(), content.NormalizeNewLines());
+        }
     }
 }

--- a/test/E2ETest/testassets/init/project-types.yaml
+++ b/test/E2ETest/testassets/init/project-types.yaml
@@ -1,0 +1,10 @@
+﻿# tye application configuration file
+# read all about it at https://github.com/dotnet/tye
+#
+# when you've given us a try, we'd love to know what you think:
+#    https://aka.ms/AA7q20u
+#
+name: project-types
+services:
+- name: app
+  project: app/app.csproj

--- a/test/E2ETest/testassets/projects/project-types/app/Program.cs
+++ b/test/E2ETest/testassets/projects/project-types/app/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace app
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/test/E2ETest/testassets/projects/project-types/app/Properties/launchSettings.json
+++ b/test/E2ETest/testassets/projects/project-types/app/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false, 
+    "anonymousAuthentication": true, 
+    "iisExpress": {
+      "applicationUrl": "http://localhost:31902",
+      "sslPort": 44339
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "app": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/test/E2ETest/testassets/projects/project-types/app/Startup.cs
+++ b/test/E2ETest/testassets/projects/project-types/app/Startup.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace app
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapGet("/", async context =>
+                {
+                    await context.Response.WriteAsync("Hello World!");
+                });
+            });
+        }
+    }
+}

--- a/test/E2ETest/testassets/projects/project-types/app/app.csproj
+++ b/test/E2ETest/testassets/projects/project-types/app/app.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/test/E2ETest/testassets/projects/project-types/app/appsettings.Development.json
+++ b/test/E2ETest/testassets/projects/project-types/app/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/test/E2ETest/testassets/projects/project-types/app/appsettings.json
+++ b/test/E2ETest/testassets/projects/project-types/app/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/test/E2ETest/testassets/projects/project-types/class-library/class-library.csproj
+++ b/test/E2ETest/testassets/projects/project-types/class-library/class-library.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>class_library</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/test/E2ETest/testassets/projects/project-types/project-types.sln
+++ b/test/E2ETest/testassets/projects/project-types/project-types.sln
@@ -1,0 +1,62 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "app", "app\app.csproj", "{F9D2F74A-9CC5-41E2-AB54-43AB9E4EB32F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test-project", "test-project\test-project.csproj", "{EEE93347-434A-4C20-B755-41D83C9B7B07}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "class-library", "class-library\class-library.csproj", "{BEF59C6C-BEC4-4CFF-9602-44B0089478A4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F9D2F74A-9CC5-41E2-AB54-43AB9E4EB32F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9D2F74A-9CC5-41E2-AB54-43AB9E4EB32F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9D2F74A-9CC5-41E2-AB54-43AB9E4EB32F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F9D2F74A-9CC5-41E2-AB54-43AB9E4EB32F}.Debug|x64.Build.0 = Debug|Any CPU
+		{F9D2F74A-9CC5-41E2-AB54-43AB9E4EB32F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F9D2F74A-9CC5-41E2-AB54-43AB9E4EB32F}.Debug|x86.Build.0 = Debug|Any CPU
+		{F9D2F74A-9CC5-41E2-AB54-43AB9E4EB32F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9D2F74A-9CC5-41E2-AB54-43AB9E4EB32F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9D2F74A-9CC5-41E2-AB54-43AB9E4EB32F}.Release|x64.ActiveCfg = Release|Any CPU
+		{F9D2F74A-9CC5-41E2-AB54-43AB9E4EB32F}.Release|x64.Build.0 = Release|Any CPU
+		{F9D2F74A-9CC5-41E2-AB54-43AB9E4EB32F}.Release|x86.ActiveCfg = Release|Any CPU
+		{F9D2F74A-9CC5-41E2-AB54-43AB9E4EB32F}.Release|x86.Build.0 = Release|Any CPU
+		{EEE93347-434A-4C20-B755-41D83C9B7B07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEE93347-434A-4C20-B755-41D83C9B7B07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEE93347-434A-4C20-B755-41D83C9B7B07}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EEE93347-434A-4C20-B755-41D83C9B7B07}.Debug|x64.Build.0 = Debug|Any CPU
+		{EEE93347-434A-4C20-B755-41D83C9B7B07}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EEE93347-434A-4C20-B755-41D83C9B7B07}.Debug|x86.Build.0 = Debug|Any CPU
+		{EEE93347-434A-4C20-B755-41D83C9B7B07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEE93347-434A-4C20-B755-41D83C9B7B07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEE93347-434A-4C20-B755-41D83C9B7B07}.Release|x64.ActiveCfg = Release|Any CPU
+		{EEE93347-434A-4C20-B755-41D83C9B7B07}.Release|x64.Build.0 = Release|Any CPU
+		{EEE93347-434A-4C20-B755-41D83C9B7B07}.Release|x86.ActiveCfg = Release|Any CPU
+		{EEE93347-434A-4C20-B755-41D83C9B7B07}.Release|x86.Build.0 = Release|Any CPU
+		{BEF59C6C-BEC4-4CFF-9602-44B0089478A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BEF59C6C-BEC4-4CFF-9602-44B0089478A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BEF59C6C-BEC4-4CFF-9602-44B0089478A4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BEF59C6C-BEC4-4CFF-9602-44B0089478A4}.Debug|x64.Build.0 = Debug|Any CPU
+		{BEF59C6C-BEC4-4CFF-9602-44B0089478A4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BEF59C6C-BEC4-4CFF-9602-44B0089478A4}.Debug|x86.Build.0 = Debug|Any CPU
+		{BEF59C6C-BEC4-4CFF-9602-44B0089478A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BEF59C6C-BEC4-4CFF-9602-44B0089478A4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BEF59C6C-BEC4-4CFF-9602-44B0089478A4}.Release|x64.ActiveCfg = Release|Any CPU
+		{BEF59C6C-BEC4-4CFF-9602-44B0089478A4}.Release|x64.Build.0 = Release|Any CPU
+		{BEF59C6C-BEC4-4CFF-9602-44B0089478A4}.Release|x86.ActiveCfg = Release|Any CPU
+		{BEF59C6C-BEC4-4CFF-9602-44B0089478A4}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/test/E2ETest/testassets/projects/project-types/test-project/UnitTest1.cs
+++ b/test/E2ETest/testassets/projects/project-types/test-project/UnitTest1.cs
@@ -1,0 +1,14 @@
+using System;
+using Xunit;
+
+namespace test_project
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+
+        }
+    }
+}

--- a/test/E2ETest/testassets/projects/project-types/test-project/test-project.csproj
+++ b/test/E2ETest/testassets/projects/project-types/test-project/test-project.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>test_project</RootNamespace>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes: #206

This change only applies to the logic that we use to look at solution
files. This adds a heuristic that we only include projects with a
launchSettings.json for these operations (when considering a solution).
This will exclude unit test projects and class libraries.

In this case where the user has a `tye.yaml` then whatever's in there
will win. Likewise if a user passes a path to a project directly then
we'll try to run it without asking questions.

I chose `launchSettings.json` for this because it's a decision we can
make really quickly without having to run any MSBuild code. When we
think about operating on a solution with 50 projects with `tye run` we
really really don't want to have to evaluate each project with MSBuild
to figure out what kind of project it is (500ms).