### PR TITLE
Update dapr version

### DIFF
--- a/samples/dapr/orders/orders.csproj
+++ b/samples/dapr/orders/orders.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="0.5.0-preview02 " />
+    <PackageReference Include="Dapr.AspNetCore" Version="0.6.0-preview01" />
   </ItemGroup>
 
 </Project>

--- a/samples/dapr/products/products.csproj
+++ b/samples/dapr/products/products.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="0.5.0-preview02 " />
+    <PackageReference Include="Dapr.AspNetCore" Version="0.6.0-preview01" />
   </ItemGroup>
 
 </Project>

--- a/samples/dapr/store/store.csproj
+++ b/samples/dapr/store/store.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="0.5.0-preview02 " />
+    <PackageReference Include="Dapr.AspNetCore" Version="0.6.0-preview01" />
   </ItemGroup>
   
 </Project>

--- a/src/Microsoft.Tye.Hosting/Model/Application.cs
+++ b/src/Microsoft.Tye.Hosting/Model/Application.cs
@@ -38,6 +38,10 @@ namespace Microsoft.Tye.Hosting.Model
                 // Inject normal configuration
                 foreach (var pair in service.Description.Configuration)
                 {
+                    if (pair.Name == "METRICS_PORT")
+                    {
+                        Console.WriteLine("wow");
+                    }
                     if (pair.Value is object)
                     {
                         set(pair.Name, pair.Value);
@@ -57,7 +61,7 @@ namespace Microsoft.Tye.Hosting.Model
 
             static string GetValueFromBinding(List<EffectiveBinding> bindings, EnvironmentVariableSource source)
             {
-                var binding = bindings.Where(b => b.Service == b.Service && b.Name == source.Binding).FirstOrDefault();
+                var binding = bindings.Where(b => b.Service == source.Service && b.Name == source.Binding).FirstOrDefault();
                 if (binding == null)
                 {
                     throw new InvalidOperationException($"Could not find binding '{source.Binding}' for service '{source.Service}'.");

--- a/src/Microsoft.Tye.Hosting/Model/Application.cs
+++ b/src/Microsoft.Tye.Hosting/Model/Application.cs
@@ -38,10 +38,6 @@ namespace Microsoft.Tye.Hosting.Model
                 // Inject normal configuration
                 foreach (var pair in service.Description.Configuration)
                 {
-                    if (pair.Name == "METRICS_PORT")
-                    {
-                        Console.WriteLine("wow");
-                    }
                     if (pair.Value is object)
                     {
                         set(pair.Name, pair.Value);


### PR DESCRIPTION
Fixes https://github.com/dotnet/tye/issues/285.

Having trouble running this locally at the moment due to the error:

```
"failed to start metrics server: listen tcp :49398: bind: Only one usage of each socket address (protocol/network address/port) is normally permitted.
```

