### PR TITLE
Don't log when pipe is broken

### DIFF
--- a/src/Microsoft.Tye.Hosting.Diagnostics/DiagnosticsCollector.cs
+++ b/src/Microsoft.Tye.Hosting.Diagnostics/DiagnosticsCollector.cs
@@ -197,23 +197,9 @@ namespace Microsoft.Tye.Hosting.Diagnostics
                 {
                     session = client.StartEventPipeSession(providers);
                 }
-                catch (EndOfStreamException)
-                {
-                    break;
-                }
                 // If the process has already exited, a ServerNotAvailableException will be thrown.
-                catch (ServerNotAvailableException)
+                catch (Exception)
                 {
-                    break;
-                }
-                catch (Exception ex)
-                {
-                    if (!cancellationToken.IsCancellationRequested)
-                    {
-                        _logger.LogDebug(0, ex, "Failed to start the event pipe session");
-                    }
-
-                    // We can't even start the session, wait until the process boots up again to start another metrics thread
                     break;
                 }
 


### PR DESCRIPTION
For https://github.com/dotnet/tye/issues/212.

I think no matter what, there will be a race condition here at the moment. I have an idea about to actually fix this, but want to bounce this off people first.

The issue lies in the fact that the ProcessRunner is stopped before the EventPipeDiagnosticRunner: https://github.com/dotnet/tye/blob/master/src/Microsoft.Tye.Hosting/AggregateApplicationProcessor.cs#L35 (list is reversed, ProcessRunner is last in the list so it is first to shutdown). Now, in between the time where the StopAsync is called on the EventPipeDiagnosticRunner, the process has shutdown, which will restart the call to StartEventPipeSession, which will fail because the process shutdown.

@davidfowl do you think it's reasonable to move the EventPipeDiagnosticRunner after the ProcessRunner in the pipeline? From what I can tell, it seems fine, but wanted to double check with you before considering that option.

Otherwise, I changed the code to catch all exceptions instead, which honestly seems reasonable as well rather than having to think harder about these shutdown interleavings.