### PR TITLE
connectionstring lowercase for kubernetes

### DIFF
--- a/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
+++ b/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Tye
                                             { "secretKeyRef", new YamlMappingNode()
                                                 {
                                                     { "name", new YamlScalarNode(binding.Name) { Style = ScalarStyle.SingleQuoted } },
-                                                    { "key", new YamlScalarNode("connectionString") { Style = ScalarStyle.SingleQuoted } },
+                                                    { "key", new YamlScalarNode("connectionstring") { Style = ScalarStyle.SingleQuoted } },
                                                 }
                                             },
                                         }

--- a/test/E2ETest/testassets/generate/generate-connectionstring-dependency.yaml
+++ b/test/E2ETest/testassets/generate/generate-connectionstring-dependency.yaml
@@ -29,7 +29,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: 'binding-production-dependency-secret'
-              key: 'connectionString'
+              key: 'connectionstring'
         ports:
         - containerPort: 80
 ...


### PR DESCRIPTION
Ran into during verification. connectionString vs connectionstring in kubernetes.

If we prefer connectionString, I can change the other place instead.