### PR TITLE
Update link to redis manifest

### DIFF
--- a/docs/tutorials/hello-tye/02_add_redis.md
+++ b/docs/tutorials/hello-tye/02_add_redis.md
@@ -115,7 +115,7 @@ We just showed how `tye` makes it easier to communicate between 2 applications r
     `tye deploy` will not deploy the redis configuration, so you need to deploy it first. Run:
 
     ```text
-    kubectl apply -f https://raw.githubusercontent.com/dotnet/tye/master/docs/yaml/redis.yaml
+    kubectl apply -f https://raw.githubusercontent.com/dotnet/tye/master/docs/tutorials/hello-tye/redis.yaml
     ```
 
     This will create a deployment and service for redis. You can see that by running:


### PR DESCRIPTION
Looks like the example redis deployment got moved to another part of the repo.