### PR TITLE
[DOCS] Align "project" and "name" nodes in 01_deploy.md of the default tye.yaml

### DIFF
--- a/docs/tutorials/hello-tye/01_deploy.md
+++ b/docs/tutorials/hello-tye/01_deploy.md
@@ -106,9 +106,9 @@ Tye has a optional configuration file (`tye.yaml`) to allow customizing settings
     name: microservice
     services:
     - name: frontend
-    project: frontend/frontend.csproj
+      project: frontend/frontend.csproj
     - name: backend
-    project: backend/backend.csproj
+      project: backend/backend.csproj
     ```
 
     The top level scope (like the `name` node) is where global settings are applied.


### PR DESCRIPTION
Changing yaml indentation of [01_deploy.md](https://github.com/dotnet/tye/blob/release/0.1/docs/tutorials/hello-tye/01_deploy.md)

from
```yaml
name: microservice
services:
- name: frontend
project: frontend/frontend.csproj
- name: backend
project: backend/backend.csproj
```

to
```yaml
name: microservice
services:
- name: frontend
  project: frontend/frontend.csproj
- name: backend
  project: backend/backend.csproj
```