### PR TITLE
Restore.cmd fails on non-existing flags "-all" and "-nobuild"

### DIFF
--- a/restore.cmd
+++ b/restore.cmd
@@ -1,3 +1,3 @@
 @ECHO OFF
 SETLOCAL
-PowerShell -NoProfile -NoLogo -ExecutionPolicy ByPass -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%~dp0eng\common\Build.ps1' -all -nobuild -restore %*; exit $LASTEXITCODE"
+PowerShell -NoProfile -NoLogo -ExecutionPolicy ByPass -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%~dp0eng\common\Build.ps1' -restore %*; exit $LASTEXITCODE"


### PR DESCRIPTION
# What
In `dotnet/tye` the `restore.cmd` directly call `./eng/common/Build.ps1` (dotnet/arcade)  
It does try to call this script with `-all` and `-nobuild`
`./eng/common/Build.ps1` script does not have sutch switch `-all` or `-nobuild`

# Why ?
Original error :
![image](https://user-images.githubusercontent.com/2266487/79134704-6cb7fc80-7dae-11ea-8d8a-7c44bddd31cc.png)

After removing `-all` :
![image](https://user-images.githubusercontent.com/2266487/79134754-7e010900-7dae-11ea-9f12-c06fcf553ec5.png)

# Investigation
It seems that this logic was added to look like the one on `dotnet/aspnetcore`, the difference between both repository is that:
* dotnet/tye directly calls `./eng/common/Build.ps1` (no such switch)
* dotnet/aspnetcore calls first `./build.ps1` (the switch logic is in there), and later on call `./eng/common/Build.ps1`

## Side effect (aka: what we "loose" on merge)
### `-all`
TLDR :  Probably not important for now in this repo does not have (yet ?) any Node/Java Build to handle

After trying to understand the `build.ps1` at root level of `dotnet/aspnetcore`
here is what the `-all` does :

* Set/Add an MsBuild property `BuildAllProjects` to true
```pwsh
if ($All) {
    $MSBuildArguments += '/p:BuildAllProjects=true'
}
```
* Detect if Node/Java are present + Warn/Error
```pwsh
if ($BuildManaged -or ($All -and (-not $NoBuildManaged))) {
    if ((-not $BuildNodeJS) -and (-not $NoBuildNodeJS)) {
        $node = Get-Command node -ErrorAction Ignore -CommandType Application
    }
    ... Logs here
}
...
if (-not $foundJdk -and $RunBuild -and ($All -or $BuildJava) -and -not $NoBuildJava) {
    Write-Error "Could not find the JDK......"
}
```

### `-nobuild`
```pwsh
$RunBuild = if ($NoBuild) { $false } else { $true }

# Run restore by default unless -NoRestore is set.
# -NoBuild implies -NoRestore, unless -Restore is explicitly set (as in restore.cmd)
$RunRestore = if ($NoRestore) { $false }
    elseif ($Restore) { $true }
    elseif ($NoBuild) { $false }
    else { $true }

# Target selection
$MSBuildArguments += "/p:Restore=$RunRestore"
$MSBuildArguments += "/p:Build=$RunBuild"
if (-not $RunBuild) {
    $MSBuildArguments += "/p:NoBuild=true"
}
```