### PR TITLE
Tye deploy nit

### DIFF
--- a/docs/tutorials/hello-tye/01_deploy.md
+++ b/docs/tutorials/hello-tye/01_deploy.md
@@ -124,7 +124,6 @@ Tye has a optional configuration file (`tye.yaml`) to allow customizing settings
     Based on what container registry you configured, add the following line in the `tye.yaml` file:
 
     ```yaml
-    name: microservice
     registry: <registry_name>
     ```
 


### PR DESCRIPTION
People have been copying the entire content rather than just the registry, causing a parsing exception due to multiple names.