### PR TITLE
Add registry name to redis yaml

### DIFF
--- a/docs/tutorials/hello-tye/02_add_redis.md
+++ b/docs/tutorials/hello-tye/02_add_redis.md
@@ -77,6 +77,7 @@ We just showed how `tye` makes it easier to communicate between 2 applications r
 
    ```yaml
     name: microservice
+    registry: <registry_name>
     services:
     - name: backend
       project: backend\backend.csproj


### PR DESCRIPTION
The second step of deploy already adds a registry, which we delete in this step.