### PR TITLE
Support dapr log level and config for local run

### DIFF
--- a/samples/dapr/tye.yaml
+++ b/samples/dapr/tye.yaml
@@ -7,6 +7,16 @@
 name: dapr
 extensions:
 - name: dapr
+
+  # log-level configures the log level of the dapr sidecar
+  log-level: debug
+
+  # config allows you to pass additional configuration into the dapr sidecar
+  # config will be interpreted as a named k8s resource when deployed, and will be interpreted as
+  # a file on disk when running locally at `./components/myconfig.yaml`
+  #
+  # config: myconfig
+  
 services:
 - name: orders
   project: orders/orders.csproj

--- a/src/Microsoft.Tye.Core/ExtensionContext.cs
+++ b/src/Microsoft.Tye.Core/ExtensionContext.cs
@@ -6,13 +6,16 @@ namespace Microsoft.Tye
 {
     public sealed class ExtensionContext
     {
-        public ExtensionContext(ApplicationBuilder application, OperationKind operation)
+        public ExtensionContext(ApplicationBuilder application, OutputContext output, OperationKind operation)
         {
             Application = application;
+            Output = output;
             Operation = operation;
         }
 
         public ApplicationBuilder Application { get; }
+
+        public OutputContext Output { get; }
 
         public OperationKind Operation { get; }
 

--- a/src/tye/ApplicationBuilderExtensions.cs
+++ b/src/tye/ApplicationBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Tye
     {
         // For layering reasons this has to live in the `tye` project. We don't want to leak
         // the extensions themselves into Tye.Core.
-        public static async Task ProcessExtensionsAsync(this ApplicationBuilder application, ExtensionContext.OperationKind operation)
+        public static async Task ProcessExtensionsAsync(this ApplicationBuilder application, OutputContext output, ExtensionContext.OperationKind operation)
         {
             foreach (var extensionConfig in application.Extensions)
             {
@@ -23,7 +23,7 @@ namespace Microsoft.Tye
                     throw new CommandException($"Could not find the extension '{extensionConfig.Name}'.");
                 }
 
-                var context = new ExtensionContext(application, operation);
+                var context = new ExtensionContext(application, output, operation);
                 await extension.ProcessAsync(context, extensionConfig);
             }
         }

--- a/src/tye/BuildHost.cs
+++ b/src/tye/BuildHost.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Tye
 
         public static async Task ExecuteBuildAsync(OutputContext output, ApplicationBuilder application, string environment, bool interactive)
         {
-            await application.ProcessExtensionsAsync(ExtensionContext.OperationKind.Deploy);
+            await application.ProcessExtensionsAsync(output, ExtensionContext.OperationKind.Deploy);
 
             var steps = new List<ServiceExecutor.Step>()
             {

--- a/src/tye/GenerateHost.cs
+++ b/src/tye/GenerateHost.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Tye
 
         public static async Task ExecuteGenerateAsync(OutputContext output, ApplicationBuilder application, string environment, bool interactive)
         {
-            await application.ProcessExtensionsAsync(ExtensionContext.OperationKind.Deploy);
+            await application.ProcessExtensionsAsync(output, ExtensionContext.OperationKind.Deploy);
 
             var steps = new List<ServiceExecutor.Step>()
             {

--- a/src/tye/Program.DeployCommand.cs
+++ b/src/tye/Program.DeployCommand.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Tye
                 throw new CommandException($"Cannot apply manifests because kubectl is not connected to a cluster.");
             }
 
-            await application.ProcessExtensionsAsync(ExtensionContext.OperationKind.Deploy);
+            await application.ProcessExtensionsAsync(output, ExtensionContext.OperationKind.Deploy);
 
             var steps = new List<ServiceExecutor.Step>()
             {

--- a/src/tye/Program.PushCommand.cs
+++ b/src/tye/Program.PushCommand.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Tye
 
         private static async Task ExecutePushAsync(OutputContext output, ApplicationBuilder application, string environment, bool interactive, bool force)
         {
-            await application.ProcessExtensionsAsync(ExtensionContext.OperationKind.Deploy);
+            await application.ProcessExtensionsAsync(output, ExtensionContext.OperationKind.Deploy);
 
             var steps = new List<ServiceExecutor.Step>()
             {

--- a/src/tye/Program.RunCommand.cs
+++ b/src/tye/Program.RunCommand.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Tye
                     throw new CommandException($"No services found in \"{application.Source.Name}\"");
                 }
 
-                await application.ProcessExtensionsAsync(ExtensionContext.OperationKind.LocalRun);
+                await application.ProcessExtensionsAsync(output, ExtensionContext.OperationKind.LocalRun);
 
                 InitializeThreadPoolSettings(application.Services.Count);
 


### PR DESCRIPTION
Fixes #296

Adds conditional logic for passing these properties to `daprd`.

Corrects logic for dealing with config. Dapr's config annotation in k8s
refers to kubernetes resource by name, but that's not possible with
local run. In local run `dapr` will expect the `-config` parameter to be
a file on disk. So, this change adds logic to look for a file by naming
convention and pass that locally instead.

Additionally added the ability for an extension to output to the console
- this is needed because we want to tell the user if their config file
can't be found, and specifically where we looked. I made the decision to
log a message and skip if the config file isn't present, because we
don't have a way to make settings conditional based on environment yet -
it makes sense that someone might need to have a config in production
but not in local dev.