### PR TITLE
Fix bad namespace changes in test projects

### DIFF
--- a/test/E2ETest/TyeBuildTests.Dockerfile.cs
+++ b/test/E2ETest/TyeBuildTests.Dockerfile.cs
@@ -6,9 +6,9 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Tye;
-using Test.Infrastucture;
+using Test.Infrastructure;
 using Xunit;
-using static Test.Infrastucture.TestHelpers;
+using static Test.Infrastructure.TestHelpers;
 
 namespace E2ETest
 {

--- a/test/E2ETest/TyeBuildTests.cs
+++ b/test/E2ETest/TyeBuildTests.cs
@@ -5,9 +5,9 @@
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Tye;
-using Test.Infrastucture;
+using Test.Infrastructure;
 using Xunit.Abstractions;
-using static Test.Infrastucture.TestHelpers;
+using static Test.Infrastructure.TestHelpers;
 
 namespace E2ETest
 {

--- a/test/E2ETest/TyeGenerateTests.cs
+++ b/test/E2ETest/TyeGenerateTests.cs
@@ -6,10 +6,10 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Tye;
-using Test.Infrastucture;
+using Test.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
-using static Test.Infrastucture.TestHelpers;
+using static Test.Infrastructure.TestHelpers;
 
 namespace E2ETest
 {

--- a/test/E2ETest/TyeInitTests.cs
+++ b/test/E2ETest/TyeInitTests.cs
@@ -6,12 +6,12 @@ using System;
 using System.IO;
 using Microsoft.Tye;
 using Microsoft.Tye.ConfigModel;
-using Test.Infrastucture;
+using Test.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
-using static Test.Infrastucture.TestHelpers;
+using static Test.Infrastructure.TestHelpers;
 
 namespace E2ETest
 {

--- a/test/E2ETest/TyePurgeTests.cs
+++ b/test/E2ETest/TyePurgeTests.cs
@@ -11,10 +11,10 @@ using System.Threading.Tasks;
 using Microsoft.Tye;
 using Microsoft.Tye.Hosting;
 using Microsoft.Tye.Hosting.Model;
-using Test.Infrastucture;
+using Test.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
-using static Test.Infrastucture.TestHelpers;
+using static Test.Infrastructure.TestHelpers;
 
 namespace E2ETest
 {

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -15,10 +15,10 @@ using Microsoft.Tye;
 using Microsoft.Tye.Hosting;
 using Microsoft.Tye.Hosting.Model;
 using Microsoft.Tye.Hosting.Model.V1;
-using Test.Infrastucture;
+using Test.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
-using static Test.Infrastucture.TestHelpers;
+using static Test.Infrastructure.TestHelpers;
 
 namespace E2ETest
 {

--- a/test/Test.Infrastructure/ConditionalFactAttribute.cs
+++ b/test/Test.Infrastructure/ConditionalFactAttribute.cs
@@ -6,10 +6,10 @@ using System;
 using Xunit;
 using Xunit.Sdk;
 
-namespace Test.Infrastucture
+namespace Test.Infrastructure
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    [XunitTestCaseDiscoverer("E2ETest." + nameof(ConditionalFactDiscoverer), "Microsoft.Tye.E2ETest")]
+    [XunitTestCaseDiscoverer("Test.Infrastructure." + nameof(ConditionalFactDiscoverer), "Test.Infrastructure")]
     public class ConditionalFactAttribute : FactAttribute
     {
     }

--- a/test/Test.Infrastructure/ConditionalFactDiscoverer.cs
+++ b/test/Test.Infrastructure/ConditionalFactDiscoverer.cs
@@ -6,7 +6,7 @@ using Xunit.Abstractions;
 using Xunit.Sdk;
 
 // Do not change this namespace without changing the usage in ConditionalFactAttribute
-namespace Test.Infrastucture
+namespace Test.Infrastructure
 {
     internal class ConditionalFactDiscoverer : FactDiscoverer
     {

--- a/test/Test.Infrastructure/ConditionalTheoryAttribute.cs
+++ b/test/Test.Infrastructure/ConditionalTheoryAttribute.cs
@@ -9,7 +9,7 @@ using Xunit.Sdk;
 namespace E2ETest
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    [XunitTestCaseDiscoverer("E2ETest." + nameof(ConditionalTheoryDiscoverer), "Microsoft.Tye.E2ETest")]
+    [XunitTestCaseDiscoverer("Test.Infrastructure." + nameof(ConditionalTheoryDiscoverer), "Test.Infrastructure")]
     public class ConditionalTheoryAttribute : TheoryAttribute
     {
     }

--- a/test/Test.Infrastructure/ConditionalTheoryAttribute.cs
+++ b/test/Test.Infrastructure/ConditionalTheoryAttribute.cs
@@ -6,7 +6,7 @@ using System;
 using Xunit;
 using Xunit.Sdk;
 
-namespace E2ETest
+namespace Test.Infrastructure
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     [XunitTestCaseDiscoverer("Test.Infrastructure." + nameof(ConditionalTheoryDiscoverer), "Test.Infrastructure")]

--- a/test/Test.Infrastructure/ConditionalTheoryDiscoverer.cs
+++ b/test/Test.Infrastructure/ConditionalTheoryDiscoverer.cs
@@ -3,11 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Test.Infrastructure;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace E2ETest
+namespace Test.Infrastructure
 {
     internal class ConditionalTheoryDiscoverer : TheoryDiscoverer
     {

--- a/test/Test.Infrastructure/ConditionalTheoryDiscoverer.cs
+++ b/test/Test.Infrastructure/ConditionalTheoryDiscoverer.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Test.Infrastucture;
+using Test.Infrastructure;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 

--- a/test/Test.Infrastructure/DockerAssert.cs
+++ b/test/Test.Infrastructure/DockerAssert.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace Test.Infrastucture
+namespace Test.Infrastructure
 {
     public static class DockerAssert
     {

--- a/test/Test.Infrastructure/EqualityYamlNodeVisitor.cs
+++ b/test/Test.Infrastructure/EqualityYamlNodeVisitor.cs
@@ -7,7 +7,7 @@ using System.CommandLine;
 using Tye.Serialization;
 using YamlDotNet.RepresentationModel;
 
-namespace E2ETest
+namespace Test.Infrastructure
 {
     public class EqualityYamlNodeVisitor
     {

--- a/test/Test.Infrastructure/ITestCondition.cs
+++ b/test/Test.Infrastructure/ITestCondition.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Test.Infrastucture
+namespace Test.Infrastructure
 {
     public interface ITestCondition
     {

--- a/test/Test.Infrastructure/RetryHandler.cs
+++ b/test/Test.Infrastructure/RetryHandler.cs
@@ -8,7 +8,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Test.Infrastucture
+namespace Test.Infrastructure
 {
     public class RetryHandler : DelegatingHandler
     {

--- a/test/Test.Infrastructure/SkipIfDockerNotRunningAttribute.cs
+++ b/test/Test.Infrastructure/SkipIfDockerNotRunningAttribute.cs
@@ -5,7 +5,7 @@
 using System;
 using Microsoft.Tye;
 
-namespace Test.Infrastucture
+namespace Test.Infrastructure
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
     public class SkipIfDockerNotRunningAttribute : Attribute, ITestCondition

--- a/test/Test.Infrastructure/SkipOnLinuxAttribute.cs
+++ b/test/Test.Infrastructure/SkipOnLinuxAttribute.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Test.Infrastucture
+namespace Test.Infrastructure
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
     internal class SkipOnLinuxAttribute : Attribute, ITestCondition

--- a/test/Test.Infrastructure/SkippedTestCase.cs
+++ b/test/Test.Infrastructure/SkippedTestCase.cs
@@ -6,7 +6,7 @@ using System;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace Test.Infrastucture
+namespace Test.Infrastructure
 {
     public class SkippedTestCase : XunitTestCase
     {

--- a/test/Test.Infrastructure/Test.Infrastructure.csproj
+++ b/test/Test.Infrastructure/Test.Infrastructure.csproj
@@ -11,11 +11,4 @@
     <ProjectReference Include="..\..\src\Microsoft.Tye.Core\Microsoft.Tye.Core.csproj" />
     <ProjectReference Include="..\..\src\tye\tye.csproj" />
   </ItemGroup>
-
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.Tye.Hosting\Microsoft.Tye.Hosting.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Tye.Core\Microsoft.Tye.Core.csproj" />
-    <ProjectReference Include="..\..\src\tye\tye.csproj" />
-  </ItemGroup>
 </Project>

--- a/test/Test.Infrastructure/TestHelpers.cs
+++ b/test/Test.Infrastructure/TestHelpers.cs
@@ -14,7 +14,7 @@ using Microsoft.Tye.Hosting.Model;
 using Xunit;
 using Microsoft.Tye;
 
-namespace Test.Infrastucture
+namespace Test.Infrastructure
 {
     public static class TestHelpers
     {

--- a/test/Test.Infrastructure/TestMethodExtensions.cs
+++ b/test/Test.Infrastructure/TestMethodExtensions.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace Test.Infrastucture
+namespace Test.Infrastructure
 {
     public static class TestMethodExtensions
     {

--- a/test/Test.Infrastructure/TestOutputLogEventSink.cs
+++ b/test/Test.Infrastructure/TestOutputLogEventSink.cs
@@ -4,7 +4,7 @@ using Serilog.Core;
 using Serilog.Events;
 using Xunit.Abstractions;
 
-namespace Test.Infrastucture
+namespace Test.Infrastructure
 {
     public class TestOutputLogEventSink : ILogEventSink, IConsole, IStandardStreamWriter
     {

--- a/test/Test.Infrastructure/TyeAssert.cs
+++ b/test/Test.Infrastructure/TyeAssert.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using Microsoft.Tye.ConfigModel;
 using Xunit;
 
-namespace Test.Infrastucture
+namespace Test.Infrastructure
 {
     public static class TyeAssert
     {

--- a/test/Test.Infrastructure/YamlAssert.cs
+++ b/test/Test.Infrastructure/YamlAssert.cs
@@ -6,7 +6,7 @@ using Xunit;
 using Xunit.Abstractions;
 using YamlDotNet.RepresentationModel;
 
-namespace E2ETest
+namespace Test.Infrastructure
 {
     public static class YamlAssert
     {

--- a/test/UnitTests/ApplicationFactoryTests.cs
+++ b/test/UnitTests/ApplicationFactoryTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Tye;
-using Test.Infrastucture;
+using Test.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/UnitTests/TyeDeserializationTests.cs
+++ b/test/UnitTests/TyeDeserializationTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.IO;
 using System.Linq;
 using Microsoft.Tye.ConfigModel;
-using Test.Infrastucture;
+using Test.Infrastructure;
 using Tye;
 using Tye.Serialization;
 using Xunit;


### PR DESCRIPTION
Spelling mistake in test infrastructure project and I forgot to update the namespace for the skip attributes 