### PR TITLE
Fix docker image building

### DIFF
--- a/src/Microsoft.Tye.Core/DockerfileGenerator.cs
+++ b/src/Microsoft.Tye.Core/DockerfileGenerator.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Tye
             await using var stream = File.OpenWrite(filePath);
             await using var writer = new StreamWriter(stream, encoding: Encoding.UTF8, bufferSize: -1, leaveOpen: true);
 
-            var entryPoint = Path.GetFileNameWithoutExtension(project.ProjectFile.Name);
+            var entryPoint = project.AssemblyName;
             output.WriteDebugLine($"Writing Dockerfile to '{filePath}'.");
             if (container.UseMultiphaseDockerfile ?? true)
             {


### PR DESCRIPTION
- Use the assembly name as the entrypoint instead of the project file name.