### PR TITLE
Fix restore.sh

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -3,4 +3,4 @@
 set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-"$DIR/build.sh" --all --restore --no-build "$@"
+"$DIR/eng/common/build.sh" --restore "$@"


### PR DESCRIPTION
This script had some wrong arguments (bad copy-paste from a more
complex repo). The restore.cmd script already had this fixed.