### PR TITLE
Add distribute tracing recipe and extension

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@
 | Topic | Description|
 |-------|------------|
 |**[Using Ingress](recipes/ingress.md)** | Using `tye` with an ingress for serving public traffic.
+|**[Using Distributed Tracing](recipes/distributed_tracing.md)** | Using zipkin for distributed tracing.
 |**[Using Dapr with Tye](recipes/dapr.md)** | Using `tye` for local development and deployment with a [Dapr](https://dapr.io) application.
 
 

--- a/docs/recipes/distributed_tracing.md
+++ b/docs/recipes/distributed_tracing.md
@@ -1,0 +1,92 @@
+# Distributed Tracing with Zipkin
+
+> :warning: This recipe refers to features that are only available in our CI builds at the moment. These features will be part of the 0.2 release on nuget.org "soon".
+
+Distributed tracing is a key diagnostics tool in your microservices toolbelt. Distributed traces show you at a glance what operations took place across your entire application to complete some task.
+
+Zipkin is a popular open-source distributed trace storage and query system. It can show you:
+
+- Which services were involved with an end-to-end operation?
+- What are the trace IDs to reference logs for an operation?
+- What were the timings of work done in each service for an operation?
+
+## Getting Started: Enabling WC3 tracing
+
+The first step is to enable the W3C trace format in your .NET applications. **This is mandatory, you won't get traces without doing this!**
+
+> :bulb: If you want an existing sample to run, the [sample here](https://github.com/dotnet/tye/tree/master/samples/frontend-backend) will do. This sample code already initializes the trace format.
+
+You need to place the following statement somewhere early in your program:
+
+```C#
+Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+```
+
+Here's what it would look like for a typical ASP.NET Core application in `Program.cs` (recommended).
+
+```C#
+using System.Diagnostics;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace Frontend
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}
+```
+
+## Enabling Zipkin in tye.yaml
+
+The next step is to add the `zipkin` extension to your `tye.yaml`. Add the `extensions` node and its children from the example below.
+
+```yaml
+name: frontend-backend
+
+extensions:
+- name: zipkin
+
+services:
+- name: backend
+  project: backend/backend.csproj
+- name: frontend
+  project: frontend/frontend.csproj
+```
+
+## Running with zipkin
+
+That's all the required configuration. Next, launch the application with `tye run`.
+
+The dashboard should show that you've got a `zipkin` service running.
+
+<img width="1514" alt="image" src="https://user-images.githubusercontent.com/1430011/80853097-d162bc00-8be2-11ea-884b-a04b52103931.png">
+
+Visit the `frontend` service (or send some traffic to your services if you are using your own code). This will populate some data in the zipkin instance.
+
+Then visit the zipkin dashboard by clicking the link. Tye will use a fixed address of `http://localhost:9411` which is typically used by zipkin.
+
+You won't see anything at first... because you need to do a search.
+
+<img width="1356" alt="image" src="https://user-images.githubusercontent.com/1430011/80853176-5bab2000-8be3-11ea-92c6-e8c187c57a38.png">
+
+Click the magnifying glass icon (on the right) to do a search.
+
+<img width="1359" alt="image" src="https://user-images.githubusercontent.com/1430011/80853255-218e4e00-8be4-11ea-848c-4d55febb096f.png">
+
+Clicking on one of these traces can show you a breakdown of how time was spent, what URIs were accessed, status codes, etc.
+
+<img width="1203" alt="image" src="https://user-images.githubusercontent.com/1430011/80853303-98c3e200-8be4-11ea-8d33-23f49200bbb4.png">
+

--- a/samples/frontend-backend/backend/Program.cs
+++ b/samples/frontend-backend/backend/Program.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
@@ -11,6 +12,7 @@ namespace Backend
     {
         public static void Main(string[] args)
         {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
             CreateHostBuilder(args).Build().Run();
         }
 

--- a/samples/frontend-backend/frontend/Program.cs
+++ b/samples/frontend-backend/frontend/Program.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
@@ -11,6 +12,7 @@ namespace Frontend
     {
         public static void Main(string[] args)
         {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
             CreateHostBuilder(args).Build().Run();
         }
 

--- a/src/Microsoft.Tye.Core/Extension.cs
+++ b/src/Microsoft.Tye.Core/Extension.cs
@@ -8,8 +8,6 @@ namespace Microsoft.Tye
 {
     public abstract class Extension
     {
-        public abstract string Name { get; }
-
         public abstract Task ProcessAsync(ExtensionContext context, ExtensionConfiguration config);
     }
 }

--- a/src/Microsoft.Tye.Core/ExtensionContext.cs
+++ b/src/Microsoft.Tye.Core/ExtensionContext.cs
@@ -6,14 +6,17 @@ namespace Microsoft.Tye
 {
     public sealed class ExtensionContext
     {
-        public ExtensionContext(ApplicationBuilder application, OutputContext output, OperationKind operation)
+        public ExtensionContext(ApplicationBuilder application, HostOptions? options, OutputContext output, OperationKind operation)
         {
             Application = application;
+            Options = options;
             Output = output;
             Operation = operation;
         }
 
         public ApplicationBuilder Application { get; }
+
+        public HostOptions? Options { get; }
 
         public OutputContext Output { get; }
 

--- a/src/Microsoft.Tye.Core/HostOptions.cs
+++ b/src/Microsoft.Tye.Core/HostOptions.cs
@@ -3,9 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Microsoft.Tye.Hosting.Diagnostics;
 
-namespace Microsoft.Tye.Hosting
+namespace Microsoft.Tye
 {
     public class HostOptions
     {
@@ -13,9 +12,13 @@ namespace Microsoft.Tye.Hosting
 
         public List<string> Debug { get; } = new List<string>();
 
-        public DiagnosticOptions Diagnostics { get; } = new DiagnosticOptions();
+        public (string Key, string Value) DistributedTraceProvider { get; set; }
 
         public bool Docker { get; set; }
+
+        public (string Key, string Value) LoggingProvider { get; set; }
+
+        public (string Key, string Value) MetricsProvider { get; set; }
 
         public bool NoBuild { get; set; }
 

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Tye.Extensions.Dapr
 {
     internal sealed class DaprExtension : Extension
     {
-        public override string Name => "dapr";
-
         public override Task ProcessAsync(ExtensionContext context, ExtensionConfiguration config)
         {
             // If we're getting called then the user configured dapr in their tye.yaml.

--- a/src/Microsoft.Tye.Extensions/WellKnownExtensions.cs
+++ b/src/Microsoft.Tye.Extensions/WellKnownExtensions.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Tye.Extensions.Dapr;
+using Microsoft.Tye.Extensions.Zipkin;
 
 namespace Microsoft.Tye.Extensions
 {
@@ -13,6 +14,7 @@ namespace Microsoft.Tye.Extensions
         public static IReadOnlyDictionary<string, Extension> Extensions = new Dictionary<string, Extension>(StringComparer.InvariantCultureIgnoreCase)
         {
             { "dapr", new DaprExtension() },
+            { "zipkin", new ZipkinExtension() },
         };
     }
 }

--- a/src/Microsoft.Tye.Extensions/Zipkin/ZipkinExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Zipkin/ZipkinExtension.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Tye.Extensions.Zipkin
 {
     internal sealed class ZipkinExtension : Extension
     {
-        public override string Name => "zipkin";
-
         public override Task ProcessAsync(ExtensionContext context, ExtensionConfiguration config)
         {
             if (context.Application.Services.Any(s => s.Name == "zipkin"))

--- a/src/Microsoft.Tye.Hosting.Diagnostics/DiagnosticOptions.cs
+++ b/src/Microsoft.Tye.Hosting.Diagnostics/DiagnosticOptions.cs
@@ -13,27 +13,14 @@ namespace Microsoft.Tye.Hosting.Diagnostics
         public (string Key, string Value) DistributedTraceProvider { get; set; }
         public (string Key, string Value) MetricsProvider { get; set; }
 
-        public static DiagnosticOptions FromConfiguration(IConfiguration configuration)
+        public static (string, string) GetProvider(string text)
         {
-            return new DiagnosticOptions
-            {
-                LoggingProvider = GetProvider(configuration, "logs"),
-                DistributedTraceProvider = GetProvider(configuration, "dtrace"),
-                MetricsProvider = GetProvider(configuration, "metrics")
-            };
-        }
-
-        private static (string, string) GetProvider(IConfiguration configuration, string providerName)
-        {
-            var providerString = configuration[providerName];
-
-            if (string.IsNullOrEmpty(providerString))
+            if (string.IsNullOrEmpty(text))
             {
                 return (null, null);
             }
 
-            var pair = providerString.Split('=');
-
+            var pair = text.Split('=');
             if (pair.Length < 2)
             {
                 return (pair[0].Trim(), null);

--- a/src/Microsoft.Tye.Hosting/HostOptions.cs
+++ b/src/Microsoft.Tye.Hosting/HostOptions.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.Tye.Hosting.Diagnostics;
+
+namespace Microsoft.Tye.Hosting
+{
+    public class HostOptions
+    {
+        public bool Dashboard { get; set; }
+
+        public List<string> Debug { get; } = new List<string>();
+
+        public DiagnosticOptions Diagnostics { get; } = new DiagnosticOptions();
+
+        public bool Docker { get; set; }
+
+        public bool NoBuild { get; set; }
+
+        public int? Port { get; set; }
+    }
+}

--- a/src/Microsoft.Tye.Hosting/ProcessRunnerOptions.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunnerOptions.cs
@@ -14,14 +14,14 @@ namespace Microsoft.Tye.Hosting
         public string[]? ServicesToDebug { get; set; }
         public bool DebugAllServices { get; set; }
 
-        public static ProcessRunnerOptions FromArgs(string[] args, string[] servicesToDebug)
+        public static ProcessRunnerOptions FromHostOptions(HostOptions options)
         {
             return new ProcessRunnerOptions
             {
-                BuildProjects = !args.Contains("--no-build"),
-                DebugMode = args.Contains("--debug"),
-                ServicesToDebug = servicesToDebug,
-                DebugAllServices = servicesToDebug?.Contains("*", StringComparer.OrdinalIgnoreCase) ?? false
+                BuildProjects = !options.NoBuild,
+                DebugMode = options.Debug.Any(),
+                ServicesToDebug = options.Debug.ToArray(),
+                DebugAllServices = options.Debug?.Contains("*", StringComparer.OrdinalIgnoreCase) ?? false
             };
         }
     }

--- a/src/Microsoft.Tye.Hosting/TyeHost.cs
+++ b/src/Microsoft.Tye.Hosting/TyeHost.cs
@@ -248,10 +248,17 @@ namespace Microsoft.Tye.Hosting
 
         private static AggregateApplicationProcessor CreateApplicationProcessor(ReplicaRegistry replicaRegistry, HostOptions options, Microsoft.Extensions.Logging.ILogger logger)
         {
-            var diagnosticsCollector = new DiagnosticsCollector(logger, options.Diagnostics);
+            var diagnostics = new DiagnosticOptions()
+            {
+                DistributedTraceProvider = options.DistributedTraceProvider,
+                LoggingProvider = options.LoggingProvider,
+                MetricsProvider = options.MetricsProvider,
+            };
+
+            var diagnosticsCollector = new DiagnosticsCollector(logger, diagnostics);
 
             // Print out what providers were selected and their values
-            options.Diagnostics.DumpDiagnostics(logger);
+            diagnostics.DumpDiagnostics(logger);
 
             var processors = new List<IApplicationProcessor>
             {

--- a/src/Microsoft.Tye.Hosting/TyeHost.cs
+++ b/src/Microsoft.Tye.Hosting/TyeHost.cs
@@ -36,21 +36,13 @@ namespace Microsoft.Tye.Hosting
         private AggregateApplicationProcessor? _processor;
 
         private readonly Application _application;
-        private readonly string[] _args;
-        private readonly string[] _servicesToDebug;
-
+        private readonly HostOptions _options;
         private ReplicaRegistry? _replicaRegistry;
 
-        public TyeHost(Application application, string[] args)
-            : this(application, args, new string[0])
-        {
-        }
-
-        public TyeHost(Application application, string[] args, string[] servicesToDebug)
+        public TyeHost(Application application, HostOptions options)
         {
             _application = application;
-            _args = args;
-            _servicesToDebug = servicesToDebug;
+            _options = options;
         }
 
         public Application Application => _application;
@@ -78,7 +70,7 @@ namespace Microsoft.Tye.Hosting
 
         public async Task<WebApplication> StartAsync()
         {
-            var app = BuildWebApplication(_application, _args, Sink);
+            var app = BuildWebApplication(_application, _options, Sink);
             DashboardWebApplication = app;
 
             _logger = app.Logger;
@@ -88,11 +80,9 @@ namespace Microsoft.Tye.Hosting
 
             ConfigureApplication(app);
 
-            var configuration = app.Configuration;
-
             _replicaRegistry = new ReplicaRegistry(_application.ContextDirectory, _logger);
 
-            _processor = CreateApplicationProcessor(_replicaRegistry, _args, _servicesToDebug, _logger, configuration);
+            _processor = CreateApplicationProcessor(_replicaRegistry, _options, _logger);
 
             await app.StartAsync();
 
@@ -100,7 +90,7 @@ namespace Microsoft.Tye.Hosting
 
             await _processor.StartAsync(_application);
 
-            if (_args.Contains("--dashboard"))
+            if (_options.Dashboard)
             {
                 OpenDashboard(app.Addresses.First());
             }
@@ -108,12 +98,16 @@ namespace Microsoft.Tye.Hosting
             return app;
         }
 
-        private static WebApplication BuildWebApplication(
-            Application application,
-            string[] args,
-            ILogEventSink? sink)
+        private static WebApplication BuildWebApplication(Application application, HostOptions options, ILogEventSink? sink)
         {
-            var builder = WebApplication.CreateBuilder(args);
+            var args = new List<string>();
+            if (options.Port.HasValue)
+            {
+                args.Add("--port");
+                args.Add(options.Port.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
+            var builder = WebApplication.CreateBuilder(args.ToArray());
 
             // Logging for this application
             builder.Host.UseSerilog((context, configuration) =>
@@ -252,13 +246,12 @@ namespace Microsoft.Tye.Hosting
             return false;
         }
 
-        private static AggregateApplicationProcessor CreateApplicationProcessor(ReplicaRegistry replicaRegistry, string[] args, string[] servicesToDebug, Microsoft.Extensions.Logging.ILogger logger, IConfiguration configuration)
+        private static AggregateApplicationProcessor CreateApplicationProcessor(ReplicaRegistry replicaRegistry, HostOptions options, Microsoft.Extensions.Logging.ILogger logger)
         {
-            var diagnosticOptions = DiagnosticOptions.FromConfiguration(configuration);
-            var diagnosticsCollector = new DiagnosticsCollector(logger, diagnosticOptions);
+            var diagnosticsCollector = new DiagnosticsCollector(logger, options.Diagnostics);
 
             // Print out what providers were selected and their values
-            diagnosticOptions.DumpDiagnostics(logger);
+            options.Diagnostics.DumpDiagnostics(logger);
 
             var processors = new List<IApplicationProcessor>
             {
@@ -268,11 +261,11 @@ namespace Microsoft.Tye.Hosting
                 new HttpProxyService(logger),
                 new DockerImagePuller(logger),
                 new DockerRunner(logger, replicaRegistry),
-                new ProcessRunner(logger, replicaRegistry, ProcessRunnerOptions.FromArgs(args, servicesToDebug))
+                new ProcessRunner(logger, replicaRegistry, ProcessRunnerOptions.FromHostOptions(options))
             };
 
             // If the docker command is specified then transform the ProjectRunInfo into DockerRunInfo
-            if (args.Contains("--docker"))
+            if (options.Docker)
             {
                 processors.Insert(0, new TransformProjectsIntoContainers(logger));
             }

--- a/src/tye/ApplicationBuilderExtensions.cs
+++ b/src/tye/ApplicationBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Tye
     {
         // For layering reasons this has to live in the `tye` project. We don't want to leak
         // the extensions themselves into Tye.Core.
-        public static async Task ProcessExtensionsAsync(this ApplicationBuilder application, OutputContext output, ExtensionContext.OperationKind operation)
+        public static async Task ProcessExtensionsAsync(this ApplicationBuilder application, HostOptions? options, OutputContext output, ExtensionContext.OperationKind operation)
         {
             foreach (var extensionConfig in application.Extensions)
             {
@@ -23,7 +23,7 @@ namespace Microsoft.Tye
                     throw new CommandException($"Could not find the extension '{extensionConfig.Name}'.");
                 }
 
-                var context = new ExtensionContext(application, output, operation);
+                var context = new ExtensionContext(application, options, output, operation);
                 await extension.ProcessAsync(context, extensionConfig);
             }
         }

--- a/src/tye/BuildHost.cs
+++ b/src/tye/BuildHost.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Tye
 
         public static async Task ExecuteBuildAsync(OutputContext output, ApplicationBuilder application, string environment, bool interactive)
         {
-            await application.ProcessExtensionsAsync(output, ExtensionContext.OperationKind.Deploy);
+            await application.ProcessExtensionsAsync(options: null, output, ExtensionContext.OperationKind.Deploy);
             Program.ApplyRegistry(output, application, interactive, requireRegistry: false);
 
             var executor = new ApplicationExecutor(output)

--- a/src/tye/GenerateHost.cs
+++ b/src/tye/GenerateHost.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Tye
 
         public static async Task ExecuteGenerateAsync(OutputContext output, ApplicationBuilder application, string environment, bool interactive)
         {
-            await application.ProcessExtensionsAsync(output, ExtensionContext.OperationKind.Deploy);
+            await application.ProcessExtensionsAsync(options: null, output, ExtensionContext.OperationKind.Deploy);
             Program.ApplyRegistry(output, application, interactive, requireRegistry: false);
 
             var executor = new ApplicationExecutor(output)

--- a/src/tye/Program.DeployCommand.cs
+++ b/src/tye/Program.DeployCommand.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Tye
                 throw new CommandException($"Cannot apply manifests because kubectl is not connected to a cluster.");
             }
 
-            await application.ProcessExtensionsAsync(output, ExtensionContext.OperationKind.Deploy);
+            await application.ProcessExtensionsAsync(options: null, output, ExtensionContext.OperationKind.Deploy);
             ApplyRegistry(output, application, interactive, requireRegistry: true);
 
             var executor = new ApplicationExecutor(output)

--- a/src/tye/Program.PushCommand.cs
+++ b/src/tye/Program.PushCommand.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Tye
 
         private static async Task ExecutePushAsync(OutputContext output, ApplicationBuilder application, string environment, bool interactive, bool force)
         {
-            await application.ProcessExtensionsAsync(output, ExtensionContext.OperationKind.Deploy);
+            await application.ProcessExtensionsAsync(options: null, output, ExtensionContext.OperationKind.Deploy);
             ApplyRegistry(output, application, interactive, requireRegistry: true);
 
             var executor = new ApplicationExecutor(output)

--- a/src/tye/Program.RunCommand.cs
+++ b/src/tye/Program.RunCommand.cs
@@ -92,13 +92,6 @@ namespace Microsoft.Tye
                     throw new CommandException($"No services found in \"{application.Source.Name}\"");
                 }
 
-                await application.ProcessExtensionsAsync(output, ExtensionContext.OperationKind.LocalRun);
-
-                InitializeThreadPoolSettings(application.Services.Count);
-
-                output.WriteInfoLine("Launching Tye Host...");
-                output.WriteInfoLine(string.Empty);
-
                 var options = new HostOptions()
                 {
                     Dashboard = args.Dashboard,
@@ -106,14 +99,18 @@ namespace Microsoft.Tye
                     NoBuild = args.NoBuild,
                     Port = args.Port,
 
-                    Diagnostics =
-                    {
-                        DistributedTraceProvider = DiagnosticOptions.GetProvider(args.Dtrace),
-                        LoggingProvider = DiagnosticOptions.GetProvider(args.Logs),
-                        MetricsProvider = DiagnosticOptions.GetProvider(args.Metrics),
-                    },
+                    DistributedTraceProvider = DiagnosticOptions.GetProvider(args.Dtrace),
+                    LoggingProvider = DiagnosticOptions.GetProvider(args.Logs),
+                    MetricsProvider = DiagnosticOptions.GetProvider(args.Metrics),
                 };
                 options.Debug.AddRange(args.Debug);
+
+                await application.ProcessExtensionsAsync(options, output, ExtensionContext.OperationKind.LocalRun);
+
+                InitializeThreadPoolSettings(application.Services.Count);
+
+                output.WriteInfoLine("Launching Tye Host...");
+                output.WriteInfoLine(string.Empty);
 
                 await using var host = new TyeHost(application.ToHostingApplication(), options);
                 await host.RunAsync();

--- a/src/tye/Program.RunCommand.cs
+++ b/src/tye/Program.RunCommand.cs
@@ -11,77 +11,82 @@ using System.Threading;
 using Microsoft.Tye.ConfigModel;
 using Microsoft.Tye.Extensions;
 using Microsoft.Tye.Hosting;
+using Microsoft.Tye.Hosting.Diagnostics;
 
 namespace Microsoft.Tye
 {
     static partial class Program
     {
-        private static Command CreateRunCommand(string[] args)
+        private static Command CreateRunCommand()
         {
             var command = new Command("run", "run the application")
             {
                 CommonArguments.Path_Required,
+
+                new Option("--no-build")
+                {
+                    Description = "Do not build project files before running.",
+                    Required = false
+                },
+                new Option("--port")
+                {
+                    Description = "The port to run control plane on.",
+                    Argument = new Argument<int?>("port"),
+                    Required = false
+                },
+                new Option("--logs")
+                {
+                    Description = "Write structured application logs to the specified log provider. Supported providers are 'console', 'elastic' (Elasticsearch), 'ai' (ApplicationInsights), 'seq'.",
+                    Argument = new Argument<string>("logs"),
+                    Required = false
+                },
+                new Option("--dtrace")
+                {
+                    Description = "Write distributed traces to the specified tracing provider. Supported providers are 'zipkin'.",
+                    Argument = new Argument<string>("trace"),
+                    Required = false,
+                },
+                new Option("--metrics")
+                {
+                    Description = "Write metrics to the specified metrics provider.",
+                    Argument = new Argument<string>("metrics"),
+                    Required = false
+                },
+                new Option("--debug")
+                {
+                    Argument = new Argument<string[]>("service")
+                    {
+                        Arity = ArgumentArity.ZeroOrMore,
+                    },
+                    Description = "Wait for debugger attach to specific service. Specify \"*\" to wait for all services.",
+                    Required = false
+                },
+                new Option("--docker")
+                {
+                    Description = "Run projects as docker containers.",
+                    Required = false
+                },
+                new Option("--dashboard")
+                {
+                    Description = "Launch dashboard on run.",
+                    Required = false
+                },
+
+                StandardOptions.Verbosity,
             };
 
-            // TODO: We'll need to support a --build-args
-            command.AddOption(new Option("--no-build")
-            {
-                Description = "Do not build project files before running.",
-                Required = false
-            });
-
-            command.AddOption(new Option("--port")
-            {
-                Description = "The port to run control plane on.",
-                Argument = new Argument<int>("port"),
-                Required = false
-            });
-
-            command.AddOption(new Option("--logs")
-            {
-                Description = "Write structured application logs to the specified log providers. Supported providers are console, elastic (Elasticsearch), ai (ApplicationInsights), seq.",
-                Argument = new Argument<string>("logs"),
-                Required = false
-            });
-
-            command.AddOption(new Option("--dtrace")
-            {
-                Description = "Write distributed traces to the specified providers. Supported providers are zipkin.",
-                Argument = new Argument<string>("logs"),
-                Required = false
-            });
-
-            command.AddOption(new Option("--debug")
-            {
-                Argument = new Argument<string[]>("service"),
-                Description = "Wait for debugger attach to specific service. Specify \"*\" to wait for all services.",
-                Required = false
-            });
-
-            command.AddOption(new Option("--docker")
-            {
-                Description = "Run projects as docker containers.",
-                Required = false
-            });
-
-            command.AddOption(new Option("--dashboard")
-            {
-                Description = "Launch dashboard on run.",
-                Required = false
-            });
-
-            command.Handler = CommandHandler.Create<IConsole, FileInfo, string[]>(async (console, path, debug) =>
+            command.Handler = CommandHandler.Create<RunCommandArguments>(async args =>
             {
                 // Workaround for https://github.com/dotnet/command-line-api/issues/723#issuecomment-593062654
-                if (path is null)
+                if (args.Path is null)
                 {
                     throw new CommandException("No project or solution file was found.");
                 }
 
-                var output = new OutputContext(console, Verbosity.Info);
+                var output = new OutputContext(args.Console, Verbosity.Info);
 
                 output.WriteInfoLine("Loading Application Details...");
-                var application = await ApplicationFactory.CreateAsync(output, path);
+                var application = await ApplicationFactory.CreateAsync(output, args.Path);
                 if (application.Services.Count == 0)
                 {
                     throw new CommandException($"No services found in \"{application.Source.Name}\"");
@@ -93,7 +98,24 @@ namespace Microsoft.Tye
 
                 output.WriteInfoLine("Launching Tye Host...");
                 output.WriteInfoLine(string.Empty);
-                await using var host = new TyeHost(application.ToHostingApplication(), args, debug);
+
+                var options = new HostOptions()
+                {
+                    Dashboard = args.Dashboard,
+                    Docker = args.Docker,
+                    NoBuild = args.NoBuild,
+                    Port = args.Port,
+
+                    Diagnostics =
+                    {
+                        DistributedTraceProvider = DiagnosticOptions.GetProvider(args.Dtrace),
+                        LoggingProvider = DiagnosticOptions.GetProvider(args.Logs),
+                        MetricsProvider = DiagnosticOptions.GetProvider(args.Metrics),
+                    },
+                };
+                options.Debug.AddRange(args.Debug);
+
+                await using var host = new TyeHost(application.ToHostingApplication(), options);
                 await host.RunAsync();
             });
 
@@ -113,6 +135,31 @@ namespace Microsoft.Tye
             ThreadPool.SetMinThreads(Math.Max(workerThreads, serviceCount * 4), completionPortThreads);
 
             // We use serviceCount * 4 because we currently launch multiple processes per service, this gives the dashboard some breathing room
+        }
+
+        // We have too many options to use the lambda form with each option as a parameter.
+        // This is slightly cleaner anyway.
+        private class RunCommandArguments
+        {
+            public IConsole Console { get; set; } = default!;
+
+            public bool Dashboard { get; set; }
+
+            public string[] Debug { get; set; } = Array.Empty<string>();
+
+            public string Dtrace { get; set; } = default!;
+
+            public bool Docker { get; set; }
+
+            public string Logs { get; set; } = default!;
+
+            public string Metrics { get; set; } = default!;
+
+            public bool NoBuild { get; set; }
+
+            public FileInfo Path { get; set; } = default!;
+
+            public int? Port { get; set; }
         }
     }
 }

--- a/src/tye/Program.cs
+++ b/src/tye/Program.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Tye
 
             command.AddCommand(CreateInitCommand());
             command.AddCommand(CreateGenerateCommand());
-            command.AddCommand(CreateRunCommand(args));
+            command.AddCommand(CreateRunCommand());
             command.AddCommand(CreateBuildCommand());
             command.AddCommand(CreatePushCommand());
             command.AddCommand(CreateDeployCommand());

--- a/src/tye/Program.cs
+++ b/src/tye/Program.cs
@@ -11,6 +11,7 @@ using System.CommandLine.IO;
 using System.CommandLine.Parsing;
 using System.Reflection;
 using System.Threading.Tasks;
+using Tye.Serialization;
 
 namespace Microsoft.Tye
 {
@@ -76,6 +77,16 @@ namespace Microsoft.Tye
                 {
                     context.Console.Error.WriteLine();
                     context.Console.Error.WriteLine(command.InnerException.ToString());
+                }
+            }
+            else if (exception is TyeYamlException yaml)
+            {
+                context.Console.Error.WriteLine($"{yaml.Message}");
+
+                if (yaml.InnerException != null)
+                {
+                    context.Console.Error.WriteLine();
+                    context.Console.Error.WriteLine(yaml.InnerException.ToString());
                 }
             }
             else

--- a/test/E2ETest/TyePurgeTests.cs
+++ b/test/E2ETest/TyePurgeTests.cs
@@ -38,7 +38,7 @@ namespace E2ETest
             var tyeDir = new DirectoryInfo(Path.Combine(projectDirectory.DirectoryPath, ".tye"));
             var outputContext = new OutputContext(_sink, Verbosity.Debug);
             var application = await ApplicationFactory.CreateAsync(outputContext, projectFile);
-            var host = new TyeHost(application.ToHostingApplication(), Array.Empty<string>())
+            var host = new TyeHost(application.ToHostingApplication(), new HostOptions())
             {
                 Sink = _sink,
             };
@@ -76,7 +76,7 @@ namespace E2ETest
             var tyeDir = new DirectoryInfo(Path.Combine(projectDirectory.DirectoryPath, ".tye"));
             var outputContext = new OutputContext(_sink, Verbosity.Debug);
             var application = await ApplicationFactory.CreateAsync(outputContext, projectFile);
-            var host = new TyeHost(application.ToHostingApplication(), Array.Empty<string>())
+            var host = new TyeHost(application.ToHostingApplication(), new HostOptions())
             {
                 Sink = _sink,
             };

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -61,7 +61,7 @@ namespace E2ETest
 
             var client = new HttpClient(new RetryHandler(handler));
 
-            await RunHostingApplication(application, Array.Empty<string>(), async (app, uri) =>
+            await RunHostingApplication(application, new HostOptions(), async (app, uri) =>
             {
                 var frontendUri = await GetServiceUrl(client, uri, "frontend");
                 var backendUri = await GetServiceUrl(client, uri, "backend");
@@ -92,7 +92,7 @@ namespace E2ETest
 
             var client = new HttpClient(new RetryHandler(handler));
 
-            await RunHostingApplication(application, new[] { "--docker" }, async (app, uri) =>
+            await RunHostingApplication(application, new HostOptions() { Docker = true, }, async (app, uri) =>
             {
                 // Make sure we're running containers
                 Assert.True(app.Services.All(s => s.Value.Description.RunInfo is DockerRunInfo));
@@ -128,7 +128,7 @@ namespace E2ETest
 
             var client = new HttpClient(new RetryHandler(handler));
 
-            await RunHostingApplication(application, new[] { "--docker" }, async (app, uri) =>
+            await RunHostingApplication(application, new HostOptions() { Docker = true, }, async (app, uri) =>
             {
                 // Make sure we're running containers
                 Assert.True(app.Services.All(s => s.Value.Description.RunInfo is DockerRunInfo));
@@ -181,7 +181,7 @@ namespace E2ETest
 
             var client = new HttpClient(new RetryHandler(handler));
 
-            await RunHostingApplication(application, Array.Empty<string>(), async (app, uri) =>
+            await RunHostingApplication(application, new HostOptions(), async (app, uri) =>
             {
                 var frontendUri = await GetServiceUrl(client, uri, "frontend");
                 var backendUri = await GetServiceUrl(client, uri, "backend");
@@ -226,7 +226,7 @@ namespace E2ETest
 
             var client = new HttpClient(new RetryHandler(handler));
 
-            await RunHostingApplication(application, Array.Empty<string>(), async (app, uri) =>
+            await RunHostingApplication(application, new HostOptions(), async (app, uri) =>
             {
                 var frontendUri = await GetServiceUrl(client, uri, "frontend");
                 var backendUri = await GetServiceUrl(client, uri, "backend");
@@ -263,9 +263,8 @@ namespace E2ETest
             };
 
             var client = new HttpClient(new RetryHandler(handler));
-            var args = new[] { "--docker" };
 
-            await RunHostingApplication(application, args, async (app, serviceApi) =>
+            await RunHostingApplication(application, new HostOptions() { Docker = true, }, async (app, serviceApi) =>
             {
                 var serviceUri = await GetServiceUrl(client, serviceApi, "volume-test");
 
@@ -280,7 +279,7 @@ namespace E2ETest
                 Assert.Equal("Things saved to the volume!", await client.GetStringAsync(serviceUri));
             });
 
-            await RunHostingApplication(application, args, async (app, serviceApi) =>
+            await RunHostingApplication(application, new HostOptions() { Docker = true, }, async (app, serviceApi) =>
             {
                 var serviceUri = await GetServiceUrl(client, serviceApi, "volume-test");
 
@@ -322,7 +321,7 @@ namespace E2ETest
             {
                 await RunHostingApplication(
                     application,
-                    new[] { "--docker" },
+                    new HostOptions() { Docker = true, },
                     async (app, uri) =>
                     {
                         // Make sure we're running containers
@@ -374,7 +373,7 @@ namespace E2ETest
 
             await RunHostingApplication(
                 application,
-                new[] { "--docker" },
+                new HostOptions() { Docker = true, },
                 async (app, uri) =>
                 {
                     // Make sure we're running containers
@@ -423,9 +422,12 @@ namespace E2ETest
             await File.WriteAllTextAsync(Path.Combine(tempDir.DirectoryPath, "file.txt"), "This content came from the host");
 
             var client = new HttpClient(new RetryHandler(handler));
-            var args = new[] { "--docker" };
+            var options = new HostOptions()
+            {
+                Docker = true,
+            };
 
-            await RunHostingApplication(application, args, async (app, serviceApi) =>
+            await RunHostingApplication(application, options, async (app, serviceApi) =>
             {
                 var serviceUri = await GetServiceUrl(client, serviceApi, "volume-test");
 
@@ -453,7 +455,7 @@ namespace E2ETest
 
             var client = new HttpClient(new RetryHandler(handler));
 
-            await RunHostingApplication(application, Array.Empty<string>(), async (app, uri) =>
+            await RunHostingApplication(application, new HostOptions(), async (app, uri) =>
             {
                 var ingressUri = await GetServiceUrl(client, uri, "ingress");
                 var appAUri = await GetServiceUrl(client, uri, "app-a");
@@ -502,7 +504,7 @@ namespace E2ETest
 
             var client = new HttpClient(new RetryHandler(handler));
 
-            await RunHostingApplication(application, Array.Empty<string>(), async (app, uri) =>
+            await RunHostingApplication(application, new HostOptions(), async (app, uri) =>
             {
                 var nginxUri = await GetServiceUrl(client, uri, "nginx");
                 var appAUri = await GetServiceUrl(client, uri, "appA");
@@ -534,7 +536,7 @@ namespace E2ETest
             // Debug targets can be null if not specified, so make sure calling host.Start does not throw.
             var outputContext = new OutputContext(_sink, Verbosity.Debug);
             var application = await ApplicationFactory.CreateAsync(outputContext, projectFile);
-            await using var host = new TyeHost(application.ToHostingApplication(), Array.Empty<string>())
+            await using var host = new TyeHost(application.ToHostingApplication(), new HostOptions())
             {
                 Sink = _sink,
             };
@@ -562,7 +564,7 @@ namespace E2ETest
 
             var client = new HttpClient(new RetryHandler(handler));
 
-            await RunHostingApplication(application, Array.Empty<string>(), async (app, uri) =>
+            await RunHostingApplication(application, new HostOptions(), async (app, uri) =>
             {
                 var votingUri = await GetServiceUrl(client, uri, "vote");
                 var workerUri = await GetServiceUrl(client, uri, "worker");
@@ -607,7 +609,7 @@ services:
 
             var client = new HttpClient(new RetryHandler(handler));
 
-            await RunHostingApplication(application, Array.Empty<string>(), async (app, uri) =>
+            await RunHostingApplication(application, new HostOptions(), async (app, uri) =>
             {
                 var votingUri = await GetServiceUrl(client, uri, "vote");
                 var workerUri = await GetServiceUrl(client, uri, "worker");
@@ -628,9 +630,9 @@ services:
             return $"{binding.Protocol ?? "http"}://localhost:{binding.Port}";
         }
 
-        private async Task RunHostingApplication(ApplicationBuilder application, string[] args, Func<Application, Uri, Task> execute)
+        private async Task RunHostingApplication(ApplicationBuilder application, HostOptions options, Func<Application, Uri, Task> execute)
         {
-            await using var host = new TyeHost(application.ToHostingApplication(), args)
+            await using var host = new TyeHost(application.ToHostingApplication(), options)
             {
                 Sink = _sink,
             };


### PR DESCRIPTION
Adding a zipkin extension for local run (deployment is next).

This will automatically inject zipkin as a service to the application for local run. This also takes control of the `--dtrace` argument if not specified at the command line. 

Refactored how options get passed to the host, so that extensions can do stuff like this 👍 

```yaml
name: frontend-backend

# THIS IS NEW
extensions:
- name: zipkin
# endregion cool and good

services:
- name: backend
  project: backend/backend.csproj
- name: frontend
  project: frontend/frontend.csproj
```