### PR TITLE
Fixes for docker scenarios

### DIFF
--- a/src/Microsoft.Tye.Core/ContainerServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/ContainerServiceBuilder.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Tye
 
         public string Image { get; set; }
 
+        public bool IsAspNet { get; set; }
+
         public string? Args { get; set; }
 
         public int Replicas { get; set; } = 1;

--- a/src/Microsoft.Tye.Hosting/DockerRunner.cs
+++ b/src/Microsoft.Tye.Hosting/DockerRunner.cs
@@ -206,15 +206,6 @@ namespace Microsoft.Tye.Hosting
                 hostname = addresses[0].ToString();
             }
 
-            // This is .NET specific
-            var userSecretStore = GetUserSecretsPathFromSecrets();
-
-            if (!string.IsNullOrEmpty(userSecretStore))
-            {
-                // Map the user secrets on this drive to user secrets
-                docker.VolumeMappings.Add(new DockerVolume(source: userSecretStore, name: null, target: "/root/.microsoft/usersecrets:ro"));
-            }
-
             var dockerInfo = new DockerInformation(new Task[service.Description.Replicas]);
 
             async Task RunDockerContainer(IEnumerable<(int ExternalPort, int Port, int? ContainerPort, string? Protocol)> ports)
@@ -227,15 +218,7 @@ namespace Microsoft.Tye.Hosting
 
                 service.ReplicaEvents.OnNext(new ReplicaEvent(ReplicaState.Added, status));
 
-                var environment = new Dictionary<string, string>
-                {
-                    // Default to development environment
-                    ["DOTNET_ENVIRONMENT"] = "Development",
-                    ["ASPNETCORE_ENVIRONMENT"] = "Development",
-                    // Remove the color codes from the console output
-                    ["DOTNET_LOGGING__CONSOLE__DISABLECOLORS"] = "true",
-                    ["ASPNETCORE_LOGGING__CONSOLE__DISABLECOLORS"] = "true"
-                };
+                var environment = new Dictionary<string, string>();
 
                 var portString = "";
 
@@ -248,16 +231,19 @@ namespace Microsoft.Tye.Hosting
                     // 1. Tell the docker container what port to bind to
                     portString = docker.Private ? "" : string.Join(" ", ports.Select(p => $"-p {p.Port}:{p.ContainerPort ?? p.Port}"));
 
-                    // 2. Configure ASP.NET Core to bind to those same ports
-                    environment["ASPNETCORE_URLS"] = string.Join(";", ports.Select(p => $"{p.Protocol ?? "http"}://*:{p.ContainerPort ?? p.Port}"));
-
-                    // Set the HTTPS port for the redirect middleware
-                    foreach (var p in ports)
+                    if (docker.IsAspNet)
                     {
-                        if (string.Equals(p.Protocol, "https", StringComparison.OrdinalIgnoreCase))
+                        // 2. Configure ASP.NET Core to bind to those same ports
+                        environment["ASPNETCORE_URLS"] = string.Join(";", ports.Select(p => $"{p.Protocol ?? "http"}://*:{p.ContainerPort ?? p.Port}"));
+
+                        // Set the HTTPS port for the redirect middleware
+                        foreach (var p in ports)
                         {
-                            // We need to set the redirect URL to the exposed port so the redirect works cleanly
-                            environment["HTTPS_PORT"] = p.ExternalPort.ToString();
+                            if (string.Equals(p.Protocol, "https", StringComparison.OrdinalIgnoreCase))
+                            {
+                                // We need to set the redirect URL to the exposed port so the redirect works cleanly
+                                environment["HTTPS_PORT"] = p.ExternalPort.ToString();
+                            }
                         }
                     }
 
@@ -362,6 +348,8 @@ namespace Microsoft.Tye.Hosting
 
                 _logger.LogInformation("Collecting docker logs for {ContainerName}.", replica);
 
+                var backOff = TimeSpan.FromSeconds(5);
+
                 while (!dockerInfo.StoppingTokenSource.Token.IsCancellationRequested)
                 {
                     var logsRes = await ProcessUtil.RunAsync("docker", $"logs -f {containerId}",
@@ -380,13 +368,15 @@ namespace Microsoft.Tye.Hosting
                         try
                         {
                             // Avoid spamming logs if restarts are happening
-                            await Task.Delay(5000, dockerInfo.StoppingTokenSource.Token);
+                            await Task.Delay(backOff, dockerInfo.StoppingTokenSource.Token);
                         }
                         catch (OperationCanceledException)
                         {
                             break;
                         }
                     }
+
+                    backOff *= 2;
                 }
 
                 _logger.LogInformation("docker logs collection for {ContainerName} complete with exit code {ExitCode}", replica, result.ExitCode);
@@ -503,30 +493,6 @@ namespace Microsoft.Tye.Hosting
             }
 
             return Task.CompletedTask;
-        }
-
-        private static string? GetUserSecretsPathFromSecrets()
-        {
-            // This is the logic used to determine the user secrets path
-            // See https://github.com/dotnet/extensions/blob/64140f90157fec1bfd8aeafdffe8f30308ccdf41/src/Configuration/Config.UserSecrets/src/PathHelper.cs#L27
-            const string userSecretsFallbackDir = "DOTNET_USER_SECRETS_FALLBACK_DIR";
-
-            // For backwards compat, this checks env vars first before using Env.GetFolderPath
-            var appData = Environment.GetEnvironmentVariable("APPDATA");
-            var root = appData                                                                   // On Windows it goes to %APPDATA%\Microsoft\UserSecrets\
-                       ?? Environment.GetEnvironmentVariable("HOME")                             // On Mac/Linux it goes to ~/.microsoft/usersecrets/
-                       ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
-                       ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
-                       ?? Environment.GetEnvironmentVariable(userSecretsFallbackDir);            // this fallback is an escape hatch if everything else fails
-
-            if (string.IsNullOrEmpty(root))
-            {
-                return null;
-            }
-
-            return !string.IsNullOrEmpty(appData)
-                ? Path.Combine(root, "Microsoft", "UserSecrets")
-                : Path.Combine(root, ".microsoft", "usersecrets");
         }
 
         private class DockerInformation

--- a/src/Microsoft.Tye.Hosting/Model/DockerRunInfo.cs
+++ b/src/Microsoft.Tye.Hosting/Model/DockerRunInfo.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Tye.Hosting.Model
         {
             Image = image;
             Args = args;
-            IsAspNet = Image.StartsWith("mcr.microsoft.com/dotnet/core/aspnet", StringComparison.OrdinalIgnoreCase);
         }
 
         public bool Private { get; set; }

--- a/src/Microsoft.Tye.Hosting/Model/DockerRunInfo.cs
+++ b/src/Microsoft.Tye.Hosting/Model/DockerRunInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Tye.Hosting.Model
@@ -15,6 +16,7 @@ namespace Microsoft.Tye.Hosting.Model
         }
 
         public bool Private { get; set; }
+        public bool IsAspNet => Image.StartsWith("mcr.microsoft.com/dotnet/core/aspnet", StringComparison.OrdinalIgnoreCase);
 
         public string? NetworkAlias { get; set; }
 

--- a/src/Microsoft.Tye.Hosting/Model/DockerRunInfo.cs
+++ b/src/Microsoft.Tye.Hosting/Model/DockerRunInfo.cs
@@ -13,10 +13,11 @@ namespace Microsoft.Tye.Hosting.Model
         {
             Image = image;
             Args = args;
+            IsAspNet = Image.StartsWith("mcr.microsoft.com/dotnet/core/aspnet", StringComparison.OrdinalIgnoreCase);
         }
 
         public bool Private { get; set; }
-        public bool IsAspNet => Image.StartsWith("mcr.microsoft.com/dotnet/core/aspnet", StringComparison.OrdinalIgnoreCase);
+        public bool IsAspNet { get; set; }
 
         public string? NetworkAlias { get; set; }
 

--- a/src/Microsoft.Tye.Hosting/Model/EnvironmentVariable.cs
+++ b/src/Microsoft.Tye.Hosting/Model/EnvironmentVariable.cs
@@ -11,6 +11,12 @@ namespace Microsoft.Tye.Hosting.Model
             Name = name;
         }
 
+        public EnvironmentVariable(string name, string? value)
+        {
+            Name = name;
+            Value = value;
+        }
+
         public string Name { get; }
         public string? Value { get; set; }
 

--- a/src/Microsoft.Tye.Hosting/Model/ProjectRunInfo.cs
+++ b/src/Microsoft.Tye.Hosting/Model/ProjectRunInfo.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Tye.Hosting.Model
             RunCommand = project.RunCommand;
             RunArguments = project.RunArguments;
             PublishOutputPath = project.PublishDir;
+            IsAspNet = project.IsAspNet;
         }
 
         public Dictionary<string, string> BuildProperties { get; } = new Dictionary<string, string>();
@@ -34,7 +35,7 @@ namespace Microsoft.Tye.Hosting.Model
         public string TargetFrameworkName { get; set; } = default!;
         public string TargetFrameworkVersion { get; set; } = default!;
         public string TargetFramework { get; }
-
+        public bool IsAspNet { get; }
         public string Version { get; }
 
         public string AssemblyName { get; }

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -230,6 +230,8 @@ namespace Microsoft.Tye.Hosting
                     environment["PORT"] = string.Join(";", ports.Select(p => $"{p.Port}"));
                 }
 
+                var backOff = TimeSpan.FromSeconds(5);
+
                 while (!processInfo.StoppedTokenSource.IsCancellationRequested)
                 {
                     var replica = serviceName + "_" + Guid.NewGuid().ToString().Substring(0, 10).ToLower();
@@ -280,6 +282,9 @@ namespace Microsoft.Tye.Hosting
                                     _logger.LogInformation("{ServiceName} running on process id {PID}", replica, pid);
                                 }
 
+                                // Reset the backoff
+                                backOff = TimeSpan.FromSeconds(5);
+
                                 status.Pid = pid;
 
                                 WriteReplicaToStore(pid.ToString());
@@ -301,13 +306,15 @@ namespace Microsoft.Tye.Hosting
 
                         try
                         {
-                            await Task.Delay(5000, processInfo.StoppedTokenSource.Token);
+                            await Task.Delay(backOff, processInfo.StoppedTokenSource.Token);
                         }
                         catch (OperationCanceledException)
                         {
                             // Swallow cancellation exceptions and continue
                         }
                     }
+
+                    backOff *= 2;
 
                     service.Restarts++;
 

--- a/src/Microsoft.Tye.Hosting/TransformProjectsIntoContainers.cs
+++ b/src/Microsoft.Tye.Hosting/TransformProjectsIntoContainers.cs
@@ -75,7 +75,8 @@ namespace Microsoft.Tye.Hosting
             var outputFileName = project.AssemblyName + ".dll";
             var dockerRunInfo = new DockerRunInfo(containerImage, $"dotnet {outputFileName} {project.Args}")
             {
-                WorkingDirectory = "/app"
+                WorkingDirectory = "/app",
+                IsAspNet = project.IsAspNet
             };
 
             dockerRunInfo.VolumeMappings.Add(new DockerVolume(source: project.PublishOutputPath, name: null, target: "/app"));

--- a/src/tye/ApplicationBuilderExtensions.cs
+++ b/src/tye/ApplicationBuilderExtensions.cs
@@ -44,7 +44,10 @@ namespace Microsoft.Tye
                 }
                 else if (service is ContainerServiceBuilder container)
                 {
-                    var dockerRunInfo = new DockerRunInfo(container.Image, container.Args);
+                    var dockerRunInfo = new DockerRunInfo(container.Image, container.Args)
+                    {
+                        IsAspNet = container.IsAspNet
+                    };
 
                     foreach (var mapping in container.Volumes)
                     {

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -165,10 +165,10 @@ namespace E2ETest
             application.Services.Remove(project);
 
             var outputFileName = project.AssemblyName + ".dll";
-            var container = new ContainerServiceBuilder(project.Name, $"mcr.microsoft.com/dotnet/core/sdk:{project.TargetFrameworkVersion}");
+            var container = new ContainerServiceBuilder(project.Name, $"mcr.microsoft.com/dotnet/core/aspnet:{project.TargetFrameworkVersion}");
             container.Volumes.Add(new VolumeBuilder(project.PublishDir, name: null, target: "/app"));
             container.Args = $"dotnet /app/{outputFileName} {project.Args}";
-            container.Bindings.AddRange(project.Bindings);
+            container.Bindings.AddRange(project.Bindings.Where(b => b.Protocol != "https"));
 
             await ProcessUtil.RunAsync("dotnet", $"publish \"{project.ProjectFile.FullName}\" /nologo", outputDataReceived: _sink.WriteLine, errorDataReceived: _sink.WriteLine);
             application.Services.Add(container);
@@ -209,11 +209,12 @@ namespace E2ETest
             application.Services.Remove(project);
 
             var outputFileName = project.AssemblyName + ".dll";
-            var container = new ContainerServiceBuilder(project.Name, $"mcr.microsoft.com/dotnet/core/sdk:{project.TargetFrameworkVersion}");
+            var container = new ContainerServiceBuilder(project.Name, $"mcr.microsoft.com/dotnet/core/aspnet:{project.TargetFrameworkVersion}");
             container.Dependencies.UnionWith(project.Dependencies);
             container.Volumes.Add(new VolumeBuilder(project.PublishDir, name: null, target: "/app"));
             container.Args = $"dotnet /app/{outputFileName} {project.Args}";
-            container.Bindings.AddRange(project.Bindings);
+            // We're not setting up the dev cert here
+            container.Bindings.AddRange(project.Bindings.Where(b => b.Protocol != "https"));
 
             await ProcessUtil.RunAsync("dotnet", $"publish \"{project.ProjectFile.FullName}\" /nologo", outputDataReceived: _sink.WriteLine, errorDataReceived: _sink.WriteLine);
             application.Services.Add(container);

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -165,7 +165,10 @@ namespace E2ETest
             application.Services.Remove(project);
 
             var outputFileName = project.AssemblyName + ".dll";
-            var container = new ContainerServiceBuilder(project.Name, $"mcr.microsoft.com/dotnet/core/aspnet:{project.TargetFrameworkVersion}");
+            var container = new ContainerServiceBuilder(project.Name, $"mcr.microsoft.com/dotnet/core/aspnet:{project.TargetFrameworkVersion}")
+            {
+                IsAspNet = true
+            };
             container.Volumes.Add(new VolumeBuilder(project.PublishDir, name: null, target: "/app"));
             container.Args = $"dotnet /app/{outputFileName} {project.Args}";
             container.Bindings.AddRange(project.Bindings.Where(b => b.Protocol != "https"));
@@ -209,7 +212,10 @@ namespace E2ETest
             application.Services.Remove(project);
 
             var outputFileName = project.AssemblyName + ".dll";
-            var container = new ContainerServiceBuilder(project.Name, $"mcr.microsoft.com/dotnet/core/aspnet:{project.TargetFrameworkVersion}");
+            var container = new ContainerServiceBuilder(project.Name, $"mcr.microsoft.com/dotnet/core/aspnet:{project.TargetFrameworkVersion}")
+            {
+                IsAspNet = true
+            };
             container.Dependencies.UnionWith(project.Dependencies);
             container.Volumes.Add(new VolumeBuilder(project.PublishDir, name: null, target: "/app"));
             container.Args = $"dotnet /app/{outputFileName} {project.Args}";


### PR DESCRIPTION
- Support https properly inside of containers by injecting the dev cert into the right place.
- Only inject .NET specific environment for projects being transformed into containers.
- Use the same base image selection as deployment
- Added backoff to restarts

Fixes #267 