### PR TITLE
Check for output type exe

### DIFF
--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigFactory.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigFactory.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Tye.ConfigModel
             // Note, this will not work if OutputType is on separate lines.
             // TODO consider a more thorough check with xml reading, but at that point, it may be better just to read the project itself.
             var content = File.ReadAllText(projectFile.FullName);
-            return content.Contains("<OutputType>exe</OutputType>");
+            return content.Contains("<OutputType>exe</OutputType>", StringComparison.OrdinalIgnoreCase);
         }
 
         private static ConfigApplication FromYaml(FileInfo file)

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigFactory.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Tye.Serialization;
@@ -68,7 +69,7 @@ namespace Microsoft.Tye.ConfigModel
                 // We want a *fast* heuristic that excludes unit test projects and class libraries without
                 // having to load all of the projects. 
                 var launchSettings = Path.Combine(projectFile.DirectoryName, "Properties", "launchSettings.json");
-                if (File.Exists(launchSettings))
+                if (File.Exists(launchSettings) || ContainsOutputTypeExe(projectFile))
                 {
                     var service = new ConfigService()
                     {
@@ -77,10 +78,16 @@ namespace Microsoft.Tye.ConfigModel
                     };
 
                     application.Services.Add(service);
-                }
+                } 
             }
 
             return application;
+        }
+
+        private static bool ContainsOutputTypeExe(FileInfo projectFile)
+        {
+            var content = File.ReadAllText(projectFile.FullName);
+            return content.Contains("<OutputType>exe</OutputType>");
         }
 
         private static ConfigApplication FromYaml(FileInfo file)

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigFactory.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigFactory.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Tye.ConfigModel
                     };
 
                     application.Services.Add(service);
-                } 
+                }
             }
 
             return application;
@@ -86,6 +86,8 @@ namespace Microsoft.Tye.ConfigModel
 
         private static bool ContainsOutputTypeExe(FileInfo projectFile)
         {
+            // Note, this will not work if OutputType is on separate lines.
+            // TODO consider a more thorough check with xml reading, but at that point, it may be better just to read the project itself.
             var content = File.ReadAllText(projectFile.FullName);
             return content.Contains("<OutputType>exe</OutputType>");
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/tye/issues/345.

This just adds another check for <OutputType>exe</OutputType>. It's a pretty limited check.