### PR TITLE
Target 2.1 for Microsoft.Extensions.Configuration

### DIFF
--- a/src/Microsoft.Tye.Extensions.Configuration/Microsoft.Tye.Extensions.Configuration.csproj
+++ b/src/Microsoft.Tye.Extensions.Configuration/Microsoft.Tye.Extensions.Configuration.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.KeyPerFile" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
   </ItemGroup>
 
 </Project>

--- a/test/E2ETest/testassets/projects/multi-project/worker/Program.cs
+++ b/test/E2ETest/testassets/projects/multi-project/worker/Program.cs
@@ -5,7 +5,6 @@
 using System;
 using System.IO;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.KeyPerFile;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 


### PR DESCRIPTION
Right now, if you target Microsoft.Tye.Extensions.Configuration, you'll get package downgrade warnings if you are targeting netcoreapp2.1.