### PR TITLE
Trim trailing slash

### DIFF
--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.Tye.ConfigModel;
 
@@ -113,9 +114,7 @@ namespace Microsoft.Tye
                             Replicas = configService.Replicas ?? 1,
                             DockerFile = configService.DockerFile != null ? Path.Combine(source.DirectoryName, configService.DockerFile) : null,
                             // Supplying an absolute path with trailing slashes fails for DockerFileContext when calling docker build, so trim trailing slash.
-                            DockerFileContext = configService.DockerFileContext != null
-                                                    ? Path.Combine(source.DirectoryName, configService.DockerFileContext).Trim('\\').Trim('/')
-                                                    : null
+                            DockerFileContext = GetDockerFileContext(source, configService)
                         };
                         service = container;
                     }
@@ -324,6 +323,32 @@ namespace Microsoft.Tye
             }
 
             return root;
+        }
+
+        private static string? GetDockerFileContext(FileInfo source, ConfigService configService)
+        {
+            if (configService.DockerFileContext == null)
+            {
+                return null;
+            }
+
+            // On windows, calling docker build with an aboslute path that ends in a trailing slash fails,
+            // but it's the exact opposite on linux, where it needs to have the trailing slash.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return Path.TrimEndingDirectorySeparator(Path.Combine(source.DirectoryName, configService.DockerFileContext));
+            }
+            else
+            {
+                var path = Path.Combine(source.DirectoryName, configService.DockerFileContext);
+
+                if (!Path.EndsInDirectorySeparator(path))
+                {
+                    return path += Path.DirectorySeparatorChar;
+                }
+
+                return path;
+            }
         }
 
         private static ConfigApplication GetNestedConfig(ConfigApplication rootConfig, string? file)

--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Tye
                             DockerFile = configService.DockerFile != null ? Path.Combine(source.DirectoryName, configService.DockerFile) : null,
                             // Supplying an absolute path with trailing slashes fails for DockerFileContext when calling docker build, so trim trailing slash.
                             DockerFileContext = configService.DockerFileContext != null
-                                                    ? Path.Combine(source.DirectoryName, configService.DockerFileContext).Trim('\\').Trim('/') 
+                                                    ? Path.Combine(source.DirectoryName, configService.DockerFileContext).Trim('\\').Trim('/')
                                                     : null
                         };
                         service = container;

--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -112,7 +112,10 @@ namespace Microsoft.Tye
                             Args = configService.Args,
                             Replicas = configService.Replicas ?? 1,
                             DockerFile = configService.DockerFile != null ? Path.Combine(source.DirectoryName, configService.DockerFile) : null,
-                            DockerFileContext = configService.DockerFileContext != null ? Path.Combine(source.DirectoryName, configService.DockerFileContext) : null
+                            // Supplying an absolute path with trailing slashes fails for DockerFileContext when calling docker build, so trim trailing slash.
+                            DockerFileContext = configService.DockerFileContext != null
+                                                    ? Path.Combine(source.DirectoryName, configService.DockerFileContext).Trim('\\').Trim('/') 
+                                                    : null
                         };
                         service = container;
                     }

--- a/src/Microsoft.Tye.Hosting/DockerRunner.cs
+++ b/src/Microsoft.Tye.Hosting/DockerRunner.cs
@@ -208,7 +208,8 @@ namespace Microsoft.Tye.Hosting
             {
                 var dockerBuildResult = await ProcessUtil.RunAsync(
                     $"docker",
-                    $"build \"{docker.DockerFileContext?.DirectoryName ?? docker.DockerFile.DirectoryName}\" -t {dockerImage} -f \"{docker.DockerFile}\"",
+                    // Supplying an absolute path with trailing slashes fails here, so trim trailing slash.
+                    $"build \"{docker.DockerFileContext?.FullName.Trim(Path.DirectorySeparatorChar) ?? docker.DockerFile.DirectoryName}\" -t {dockerImage} -f \"{docker.DockerFile}\"",
                     docker.WorkingDirectory,
                     throwOnError: false);
 

--- a/src/Microsoft.Tye.Hosting/DockerRunner.cs
+++ b/src/Microsoft.Tye.Hosting/DockerRunner.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Tye.Hosting
             {
                 var dockerBuildResult = await ProcessUtil.RunAsync(
                     $"docker",
-                    $"build \"{docker.DockerFileContext?.FullName ?? docker.DockerFile.DirectoryName}\" -t {dockerImage} -f \"{docker.DockerFile}\"",
+                    $"build \"{docker.DockerFileContext?.FullName}\" -t {dockerImage} -f \"{docker.DockerFile}\"",
                     docker.WorkingDirectory,
                     throwOnError: false);
 

--- a/src/Microsoft.Tye.Hosting/DockerRunner.cs
+++ b/src/Microsoft.Tye.Hosting/DockerRunner.cs
@@ -208,8 +208,7 @@ namespace Microsoft.Tye.Hosting
             {
                 var dockerBuildResult = await ProcessUtil.RunAsync(
                     $"docker",
-                    // Supplying an absolute path with trailing slashes fails here, so trim trailing slash.
-                    $"build \"{docker.DockerFileContext?.FullName.Trim(Path.DirectorySeparatorChar) ?? docker.DockerFile.DirectoryName}\" -t {dockerImage} -f \"{docker.DockerFile}\"",
+                    $"build \"{docker.DockerFileContext?.FullName ?? docker.DockerFile.DirectoryName}\" -t {dockerImage} -f \"{docker.DockerFile}\"",
                     docker.WorkingDirectory,
                     throwOnError: false);
 

--- a/src/tye/ApplicationBuilderExtensions.cs
+++ b/src/tye/ApplicationBuilderExtensions.cs
@@ -57,6 +57,10 @@ namespace Microsoft.Tye
                         {
                             dockerRunInfo.DockerFileContext = new FileInfo(container.DockerFileContext);
                         }
+                        else
+                        {
+                            dockerRunInfo.DockerFileContext = new FileInfo(dockerRunInfo.DockerFile.DirectoryName);
+                        }
                     }
 
                     foreach (var mapping in container.Volumes)

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -660,9 +660,8 @@ services:
             });
         }
 
-        //[ConditionalFact]
-        //[SkipIfDockerNotRunning]
-        [Fact]
+        [ConditionalFact]
+        [SkipIfDockerNotRunning]
         public async Task DockerFileChangeContextTest()
         {
             using var projectDirectory = CopyTestProjectDirectory("dockerfile");

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -660,8 +660,9 @@ services:
             });
         }
 
-        [ConditionalFact]
-        [SkipIfDockerNotRunning]
+        //[ConditionalFact]
+        //[SkipIfDockerNotRunning]
+        [Fact]
         public async Task DockerFileChangeContextTest()
         {
             using var projectDirectory = CopyTestProjectDirectory("dockerfile");
@@ -674,6 +675,12 @@ services:
 - name: backend
   dockerFile: Dockerfile
   dockerFileContext: backend/
+  bindings:
+    - containerPort: 80
+      protocol: http
+- name: backend2
+  dockerFile: ./Dockerfile
+  dockerFileContext: ./backend
   bindings:
     - containerPort: 80
       protocol: http
@@ -697,11 +704,14 @@ services:
             {
                 var frontendUri = await GetServiceUrl(client, uri, "frontend");
                 var backendUri = await GetServiceUrl(client, uri, "backend");
+                var backend2Uri = await GetServiceUrl(client, uri, "backend2");
 
                 var backendResponse = await client.GetAsync(backendUri);
+                var backend2Response = await client.GetAsync(backend2Uri);
                 var frontendResponse = await client.GetAsync(frontendUri);
 
                 Assert.True(backendResponse.IsSuccessStatusCode);
+                Assert.True(backend2Response.IsSuccessStatusCode);
                 Assert.True(frontendResponse.IsSuccessStatusCode);
             });
         }


### PR DESCRIPTION
Fixes #471 

From what I can tell, the issue is that docker build doesn't like providing an absolute path with a trailing slash.