### PR TITLE
Remove details for external services

### DIFF
--- a/src/Microsoft.Tye.Hosting/Dashboard/Pages/Index.razor
+++ b/src/Microsoft.Tye.Hosting/Dashboard/Pages/Index.razor
@@ -21,7 +21,16 @@
             var logsPath = $"logs/{service.Description.Name}";
             var servicePath = $"services/{service.Description.Name}";
             <tr @key="service.Description.Name">
-                <td><a href="@servicePath">@service.Description.Name</a></td>
+                <td>
+                    @if(service.ServiceType == ServiceType.External)
+                    {
+                        <span>@service.Description.Name</span>
+                    }
+                    else
+                    {
+                        <a href="@servicePath">@service.Description.Name</a>
+                    }
+                </td>
                 <td>
                     @service.ServiceType
                 </td>
@@ -63,11 +72,16 @@
                         <p>none</p>
                     }
                 </td>
-                <td>@service.Replicas.Count/@service.Description.Replicas</td>
-                <td>@service.Restarts</td>
-                <td>
-                    <NavLink href="@logsPath">View</NavLink>
-                </td>
+                @if(service.ServiceType == ServiceType.External)
+                {
+                    <td colspan=3></td>
+                }
+                else
+                {
+                    <td>@service.Replicas.Count/@service.Description.Replicas</td>
+                    <td>@service.Restarts</td>
+                    <td><NavLink href="@logsPath">View</NavLink></td>
+                }
             </tr>
         }
     </tbody>


### PR DESCRIPTION
Looking at https://github.com/dotnet/tye/issues/398 and noticed that we show a bunch of things that can never work for external.

```yaml
name: tyeweather
services:
- name: weather
  project: weather/weather.csproj
  env:
    - name: API_KEY
      value: <something>
- name: weatherext
  external: true
  bindings:
    - protocol: https
      port: 441
      host: samples.openweathermap.orgz
```

Before:

![image](https://user-images.githubusercontent.com/234688/82523987-8998cb80-9ae2-11ea-9ad4-8f1c1f6fffc7.png)

After:

![image](https://user-images.githubusercontent.com/234688/82524025-afbe6b80-9ae2-11ea-8071-3cb0b4e436db.png)

