### PR TITLE
Fix dotnet feed publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,8 +118,6 @@ stages:
         - script: eng/common/cibuild.sh
             --configuration $(_BuildConfig)
             --prepareMachine
-            $(_OfficialBuildArgs)
-            /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
           displayName: Build
         - task: PublishBuildArtifacts@1
           displayName: Upload TestResults
@@ -151,7 +149,6 @@ stages:
         - script: eng/common/cibuild.sh
             --configuration $(_BuildConfig)
             --prepareMachine
-            $(_InternalRuntimeDownloadArgs)
           displayName: Build
         - task: PublishBuildArtifacts@1
           displayName: Upload TestResults


### PR DESCRIPTION
Removing the steps that create AssetManifest files from Linux to prevent the Publish task from trying to upload the same assets multiple times in parallel and fail on file locks.
Removing empty parameter on macOS step.