### PR TITLE
Small tweak to docker build

### DIFF
--- a/test/Test.Infrastructure/TestHelpers.cs
+++ b/test/Test.Infrastructure/TestHelpers.cs
@@ -19,7 +19,7 @@ namespace Test.Infrastructure
 {
     public static class TestHelpers
     {
-        private static readonly TimeSpan WaitForServicesTimeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(20);
+        private static readonly TimeSpan WaitForServicesTimeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromMinutes(1);
 
         // https://github.com/dotnet/aspnetcore/blob/5a0526dfd991419d5bce0d8ea525b50df2e37b04/src/Testing/src/TestPathUtilities.cs
         // This can get into a bad pattern for having crazy paths in places. Eventually, especially if we use helix,


### PR DESCRIPTION
- Log the output to both the main window and the service logs when building.
- Make docker build cancellable (ctrl+c)

![image](https://user-images.githubusercontent.com/95136/82722676-acabb280-9c7d-11ea-89c8-90fd17477c8e.png)


Fixes #491