### PR TITLE
Liveness and Readiness Documentation, Samples and Small Changes

### DIFF
--- a/docs/recipes/probes.md
+++ b/docs/recipes/probes.md
@@ -1,34 +1,172 @@
 # Probes in Tye
 
-Just like in a Kubernetes deployment, you can define `liveness` and `readiness` ports in Tye, as part of the service.   
+Just like in a [Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) deployment, you can define `liveness` and `readiness` ports in Tye, as part of the service.   
 
-## Definition
+Probes serve two main functions  
 
-Tye will periodically make requests to an HTTP endpoint that is provided as part of the probe definition.  
+* Keeping traffic away from replicas which are not ready to receive it.
+* Restarting replicas which are in a Bad/Unhealthy state.
 
-If that HTTP endpoint returns a non-successful status code, Tye will fail the probe. (There is a threshold for how many times the HTTP request has to fail before the Tye fails the probe. the default is `3`).  
+## Life cycle of a Replica
 
-A failed probe has a different meaning for whether it's a liveness probe or a readiness probe.  
+Before we get to the definition of a probe and how it works, it's important to understand the life cycle of a replica.  
 
-### Liveness
+Each replica in Tye can be in one of these three states  
 
-When the liveness probe fails for a certain replica, Tye restarts that replica.
+* `Started` - A replica is in this state when it has just been started, and hasn't been probed yet.  
+* `Healthy` - A replica is in this state when it passes the `liveness` probe, but not the `readiness` probe. 
+* `Ready` - A replica is in this state when it passes both the `liveness` and `readiness` probes.  
 
-### Readiness
+(*Internally, there are more states that a replica can be in, but those are not relevant to this discussion*)
 
-When the readiness probe fails for a certain replica, Tye stops routing traffic to that replica, both from its service binding, and from any ingress that routes to that service.  
+## Types of Probes  
 
- ### Absence of a Probe Definition
+There are two types of probes, both have a similar schema but serve a different purpose.  
 
- In the absence of both `liveness` and `readiness` probes, the replicas 
+### Liveness  
 
-## Getting Started with Probes
+The `liveness` probe is used to let Tye know when it can restart a replica.  
+
+When a replica is restarted due to a failed `liveness` probe, a new replica is created in its stead.
+
+### Readiness  
+
+The `readiness` probe is used to let Tye know when it's okay to route traffic to a replica.  
+
+The `readiness` probe cannot kill/restart a replica, it can only do two things
+
+* Promote `Healthy` replica to `Ready`, when the probe succeeds.
+* Demote a `Ready` replica to `Healthy` when the probe fails.  
+
+Tye only routes traffic (either via a service binding, or an ingress) to `Ready` replicas.  
+
+## Life cycle of a Replica in the Absence of Probes
+
+By now, the life cycle of a replica when both `liveness` and `readiness` probes are configured should be clear, but how does the life cycle of a replica look like when both probes or one of the probes is absent?  
+
+* When both `liveness` and `readiness` probes are absent, a replica gets promoted from `Started` to `Ready` automatically, upon creation.
+* When only the `readiness` probe is absent, a replica gets promoted from `Started` to `Healthy` only after it passes the `liveness` probe, but upon being promoted to `Healthy`, it's automatically promoted again, to `Ready`.  
+* When only the `liveness` probe is absent, a replica gets promoted from `Started` to `Healthy` automatically, upon creation, but gets promoted from `Healthy` to `Ready` only upon passing the `readiness` probe.  
+
+## Running Locally with Liveness and Readiness Probes
+
+*The section will refer to this [sample application](/samples/liveness-and-readiness/) which demonstrates basic usage.*  
+
+To run the sample locally, clone this repository or download the source and navigate to the `/samples/liveness-and-readiness/` directory in your terminal.  
+
+```
+tye run
+```
+
+The sample has a single service with a `liveness` and a `readiness` probe, as shown in this snippet
+
+```
+services:
+  - name: simple-webapi
+    project: webapi/webapi.csproj
+    replicas: 2
+    liveness:
+      http:
+        path: /healthy
+    readiness:
+      http:
+        path: /ready
+```
+
+The service is configured to respond successfully to both the `liveness` and `readiness` probes, so after you run Tye, you should see these log lines  
+
+```
+[18:14:05 INF] Replica simple-webapi_a2d67bd9-4 is moving to an healthy state
+[18:14:05 INF] Replica simple-webapi_a9c2e2f4-d is moving to an healthy state
+[18:14:07 INF] Replica simple-webapi_a9c2e2f4-d is moving to a ready state
+[18:14:07 INF] Replica simple-webapi_a2d67bd9-4 is moving to a ready state
+```
+
+As you can see, both replicas pass the `liveness` probe and get prompted to an `Healthy` state, and shortly after, both replica pass the `readiness` probe and get promoted to a `Ready` state.  
+
+The sample application exposes an endpoint that allows you modify the responses that the `/healthy` and `/ready` endpoints, in order to see the probes in action.  
+
+For example, if you send an *HTTP POST* request to this endpoint `http://localhost:8080/set` with this body  
+
+```
+{
+	"Ready": false,
+	"Timeout": 10
+}
+```  
+
+It will make `/ready` return *HTTP 500* for 10 seconds.   
+
+Shortly after issuing that requests, you should see this log line in the terminal 
+
+```
+[18:14:18 INF] Replica simple-webapi_a2d67bd9-4 is moving to an healthy state
+```
+
+meaning that the replica got demoted from `Ready` to `Healthy`, due to failing the `readiness` probe.  
+
+After *about* 10 seconds, you should see this log line in the terminal  
+
+```
+[18:14:26 INF] Replica simple-webapi_a2d67bd9-4 is moving to a ready state
+```
+
+meaning that the replica got demoted from `Healthy` to `Ready` again, due to passing the `readiness` probe.
+
+(*The reason it's a bit less than 10 seconds, is because Tye doesn't fail the probe immediately. It waits for a certain number of consecutive failures, as described in the schema document.*)  
+
+You can use the same method to make the `liveness` probe fail, and watch as Tye restarts the replica.  
+
+Send an *HTTP POST* request to this endpoint `http://localhost:8080/set` with this body
+```
+{
+    "Healthy": false
+}
+```
 
 
+And watch for this log line  
 
-## Sample Code
+```
+[18:25:08 INF] Killing replica simple-webapi_a9c2e2f4-d because it has failed the liveness probe
+```
 
-The sample code for this document can found [here](/../../samples/liveness-readiness)
+Shortly after, you should see this log lines  
 
-This application has one service, with 2 replicas and an ingress that routes into it. 
+```
+[18:25:08 INF] Launching service simple-webapi_0e7fe12d-7
+[18:25:09 INF] Replica simple-webapi_0e7fe12d-7 is moving to an healthy state
+[18:25:11 INF] Replica simple-webapi_0e7fe12d-7 is moving to a ready state
+```
 
+Showing that Tye launches a new replica instead of the replica that it has killed.
+
+## Deploying with Liveness and Readiness Probes
+
+When you deploy an application with `liveness` and/or `readiness` probes to Kubernetes, these probes get translated to their [equivalent representation in Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)  
+
+After running
+
+```
+tye deploy --interactive
+```
+
+You should see the `simple-webapi` deployment in Kubernetes
+
+```
+NAME            READY   UP-TO-DATE   AVAILABLE   AGE
+simple-webapi   2/2     2            2           90s
+```
+
+Run 
+
+```
+kubectl describe deploy simple-webapi
+```
+
+And you will notice that the deployment has `Liveness` and `Readiness` in its description  
+
+```
+Liveness:   http-get http://:80/healthy delay=0s timeout=1s period=1s #success=1 #failure=3
+Readiness:  http-get http://:80/ready delay=0s timeout=1s period=1s #success=1 #failure=3
+```

--- a/docs/recipes/probes.md
+++ b/docs/recipes/probes.md
@@ -28,7 +28,7 @@ When the readiness probe fails for a certain replica, Tye stops routing traffic 
 
 ## Sample Code
 
-The sample code for this document can found [here](../../samples/liveness-readiness)
+The sample code for this document can found [here](/../../samples/liveness-readiness)
 
 This application has one service, with 2 replicas and an ingress that routes into it. 
 

--- a/docs/recipes/probes.md
+++ b/docs/recipes/probes.md
@@ -1,0 +1,34 @@
+# Probes in Tye
+
+Just like in a Kubernetes deployment, you can define `liveness` and `readiness` ports in Tye, as part of the service.   
+
+## Definition
+
+Tye will periodically make requests to an HTTP endpoint that is provided as part of the probe definition.  
+
+If that HTTP endpoint returns a non-successful status code, Tye will fail the probe. (There is a threshold for how many times the HTTP request has to fail before the Tye fails the probe. the default is `3`).  
+
+A failed probe has a different meaning for whether it's a liveness probe or a readiness probe.  
+
+### Liveness
+
+When the liveness probe fails for a certain replica, Tye restarts that replica.
+
+### Readiness
+
+When the readiness probe fails for a certain replica, Tye stops routing traffic to that replica, both from its service binding, and from any ingress that routes to that service.  
+
+ ### Absence of a Probe Definition
+
+ In the absence of both `liveness` and `readiness` probes, the replicas 
+
+## Getting Started with Probes
+
+
+
+## Sample Code
+
+The sample code for this document can found [here](../../samples/liveness-readiness)
+
+This application has one service, with 2 replicas and an ingress that routes into it. 
+

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -502,3 +502,122 @@ The path `/mypath` or `/mypath/` will match:
 #### `host` (`string`)
 
 The host to match. 
+
+## Liveness and Readiness
+
+`liveness` and `readiness` elements appear within the properties of a `Service`.  
+
+Tye uses the `liveness` and `readiness` to probe the replicas of a service.  
+Each replica of a service is probed independently.   
+
+### Replica State  
+
+Each replica of a service has three states it can be in  
+
+* `Started` - A replica is in this state when it has just been started, and hasn't been probed yet.  
+* `Healthy` - A replica is in this state when it passes the `liveness` probe, but not the `readiness` probe. 
+* `Ready` - A replica is in this state when it passes both the `liveness` and `readiness` probes.  
+
+`liveness` and `readiness` have similar schemas, but have different meaning to the life cycle of the service.  
+
+If a `liveness` probe fails for a replica, Tye restarts that replica.  
+If a `readiness` probe fails for a replica, Tye doesn't restart that replica, but demotes the state of that replica from `Ready` to `Healthy`, until the probe becomes successful again.  
+
+`Healthy` replicas are kept alive but Tye doesn't route traffic to them. (Neither via the service binding, nor via an ingress that routes to that service)  
+
+`liveness` and `readiness` are optional, and may only be defined once per `Service`.  
+
+### Liveness and Readiness Example
+
+```
+name: myapplication
+services:
+  - name: webapi
+    project: webapi/webapi.csproj
+    replicas: 3
+    liveness:
+      http:
+        path: /healthy
+    readiness:
+      http:
+        path: /ready
+```
+
+In this example, the `webapi` service has both a `liveness` probe and a `readiness` probe.  
+The `liveness` probe periodically calls the `/healthy` endpoint in the service and the `readiness` probe periodically calls the `/ready` endpoint in the service.  
+
+### Probe Properties
+
+(This refers both to the `liveness` probe and the `readiness` probe, since both have similar properties)
+
+#### `http` (`HttpProber`) *required*  
+
+The properties of the `HttpProber` that tell Tye how to probe a replica using HTTP.  
+
+#### `period` (`integer`)  
+
+The period (in seconds) in which Tye probes a replica.  (Default value: `1`, Minimum value: `1`)  
+
+#### `timeout` (`integer`)  
+
+The time (in seconds) that Tye waits for a replica to respond to a probe, before the probe fails. (Default value: `1`, Minimum value: `1`)  
+
+#### `successThreshold` (`integer`)  *only relevant for readiness probe*  
+
+Tye will wait for this number of successes from prober, before marking a `Healthy` replica as `Ready`. (Default value: `1`, Minimum value: `1`)
+
+#### `failureThreshold` (`integer`)  
+
+Tye will wait for this number of failures from the prober, before giving up.  (Default value: `3`, Minimum value: `1`)  
+
+Giving up in the context of `liveness` probe means killing the replica, and in the context of `readiness` probe it means marking a `Ready` replica as `Healthy`.  
+
+## HttpProber  
+
+`HttpProber` appears within the `http` property of the `liveness` and `readiness` elements.  
+The `HttpProber` tells Tye which endpoint, port, protocol and which headers to use to probe the replicas of a service.  
+
+### HttpProber Example  
+
+```
+...
+liveness:
+  # An HttpProber
+  http:
+    path: /healthy
+    port: 8080
+    protocol: http
+    headers:
+      - name: HeaderA
+        value: ValueA
+      - name: HeaderB
+        value: ValueB
+  ...
+...
+```
+
+In this example, the `liveness` probe defines an `HttpProber` that will probe the replicas of the service at the `/healthy` endpoint (*HTTP GET*), on port `8080`, using HTTP (*unsecure*), and providing two headers (`HeaderA` and `HeaderB`) with the values `ValueA` and `ValueB` respectively.  
+
+### HttpProber Properties
+
+#### `path` (`string`) *required*
+
+Tye will probe the replicas of the service at that path, using the *GET* method.
+
+#### `port` (`integer`)
+
+The service binding port that is used to probe the replicas of the service.  
+
+#### `protocol` (`string`)  
+
+The service binding protocol that is used to probe the replicas of the server. (i.e. `http`/`https`)
+
+*Note:  
+If neither `port` nor `protocol` are provided, Tye selects the first binding of the service.  
+If just `port` is provided, Tye selects the first binding with that `port`.  
+If just `protocol` is provided, Tye selects the first binding with that `protocol`.  
+If both `port` and `protocol` are provided, Tye selects the first biding with that `port` and `protocol`.*
+
+#### `headers` (`(name, value)[]`)  
+
+Array of headers that are sent as part of the HTTP request that probes the replicas of the service.  

--- a/samples/liveness-and-readiness/tye.yaml
+++ b/samples/liveness-and-readiness/tye.yaml
@@ -1,0 +1,20 @@
+name: liveness-and-readiness
+ingress:
+    - name: ingress
+      bindings:
+          - port: 8080
+      rules:
+        - path: /
+          service: simple-webapi
+services:
+  - name: simple-webapi
+    project: webapi/webapi.csproj
+    replicas: 2
+    liveness:
+      http:
+        path: /healthy
+      initialDelay: 1
+    readiness:
+      http:
+        path: /ready
+      initialDelay: 1

--- a/samples/liveness-and-readiness/webapi/Program.cs
+++ b/samples/liveness-and-readiness/webapi/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace webapi
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/samples/liveness-and-readiness/webapi/Program.cs
+++ b/samples/liveness-and-readiness/webapi/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/samples/liveness-and-readiness/webapi/Properties/launchSettings.json
+++ b/samples/liveness-and-readiness/webapi/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false, 
+    "anonymousAuthentication": true, 
+    "iisExpress": {
+      "applicationUrl": "http://localhost:31334",
+      "sslPort": 44363
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "webapi": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/liveness-and-readiness/webapi/Startup.cs
+++ b/samples/liveness-and-readiness/webapi/Startup.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/samples/liveness-and-readiness/webapi/Startup.cs
+++ b/samples/liveness-and-readiness/webapi/Startup.cs
@@ -75,22 +75,17 @@ namespace webapi
                 endpoints.MapGet("/set", async context =>
                 {
                     var query = context.Request.Query.ToDictionary(kv => kv.Key).ToDictionary(kv => kv.Key, kv => kv.Value.Value.First());
-                    Console.WriteLine(context.Request.QueryString);
 
                     var originalHealthy = _healthy;
                     var originalReady = _ready;
 
-                    Console.WriteLine("Setting3...");
-
                     if (query.ContainsKey("healthy") && bool.TryParse(query["healthy"], out var healthy))
                     {
-                        Console.WriteLine("Setting Healthy: " + healthy);
                         _healthy = healthy;
                     }
 
                     if (query.ContainsKey("ready") && bool.TryParse(query["ready"], out var ready))
                     {
-                        Console.WriteLine("Setting Ready: " + ready);
                         _ready = ready;
                     }
 

--- a/samples/liveness-and-readiness/webapi/Startup.cs
+++ b/samples/liveness-and-readiness/webapi/Startup.cs
@@ -71,26 +71,32 @@ namespace webapi
                     await context.Response.WriteAsync($"Status Code: {context.Response.StatusCode}");
                 });
 
-                endpoints.MapPost("/set", async context =>
+                // Should be technically POST/PUT, but it's just for tests...
+                endpoints.MapGet("/set", async context =>
                 {
-                    var data = await JsonSerializer.DeserializeAsync<SetDTO>(context.Request.Body);
-                    
+                    var query = context.Request.Query.ToDictionary(kv => kv.Key).ToDictionary(kv => kv.Key, kv => kv.Value.Value.First());
+                    Console.WriteLine(context.Request.QueryString);
+
                     var originalHealthy = _healthy;
                     var originalReady = _ready;
 
-                    if (data.Healthy.HasValue)
+                    Console.WriteLine("Setting3...");
+
+                    if (query.ContainsKey("healthy") && bool.TryParse(query["healthy"], out var healthy))
                     {
-                        _healthy = data.Healthy.Value;
+                        Console.WriteLine("Setting Healthy: " + healthy);
+                        _healthy = healthy;
                     }
 
-                    if (data.Ready.HasValue)
+                    if (query.ContainsKey("ready") && bool.TryParse(query["ready"], out var ready))
                     {
-                        _ready = data.Ready.Value;
+                        Console.WriteLine("Setting Ready: " + ready);
+                        _ready = ready;
                     }
 
-                    if (data.Timeout.HasValue)
+                    if (query.ContainsKey("timeout") && int.TryParse(query["timeout"], out var timeout))
                     {
-                        var _ = Task.Delay(TimeSpan.FromSeconds(data.Timeout.Value))
+                        var _ = Task.Delay(TimeSpan.FromSeconds(timeout))
                             .ContinueWith(_ =>
                             {
                                 _healthy = originalHealthy;

--- a/samples/liveness-and-readiness/webapi/Startup.cs
+++ b/samples/liveness-and-readiness/webapi/Startup.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace webapi
+{
+    class SetDTO
+    {
+        public bool? Healthy { get; set; }
+        public bool? Ready { get; set; }
+    }
+
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            var id = Guid.NewGuid().ToString();
+            var healthy = true;
+            var ready = true;
+
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapGet("/", async context =>
+                {
+                    await context.Response.WriteAsync($"Hello World! Process Id: {id}");
+                });
+
+                endpoints.MapGet("/healthy", async context =>
+                {
+                    context.Response.StatusCode = healthy ? 200 : 500;
+                    await context.Response.WriteAsync($"Status Code: {context.Response.StatusCode}");
+                });
+
+                endpoints.MapGet("/ready", async context =>
+                {
+                    context.Response.StatusCode = ready ? 200 : 500;
+                    await context.Response.WriteAsync($"Status Code: {context.Response.StatusCode}");
+                });
+
+                endpoints.MapPost("/set", async context =>
+                {
+                    var data = await JsonSerializer.DeserializeAsync<SetDTO>(context.Request.Body);
+                    
+                    if (data.Healthy.HasValue)
+                    {
+                        healthy = data.Healthy.Value;
+                    }
+
+                    if (data.Ready.HasValue)
+                    {
+                        ready = data.Ready.Value;
+                    }
+
+                    await context.Response.WriteAsync("Done");
+                });
+            });
+        }
+    }
+}

--- a/samples/liveness-and-readiness/webapi/appsettings.Development.json
+++ b/samples/liveness-and-readiness/webapi/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/samples/liveness-and-readiness/webapi/appsettings.json
+++ b/samples/liveness-and-readiness/webapi/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/samples/liveness-and-readiness/webapi/webapi.csproj
+++ b/samples/liveness-and-readiness/webapi/webapi.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigApplication.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigApplication.cs
@@ -146,13 +146,13 @@ namespace Microsoft.Tye.ConfigModel
                             $"Probe '{probe.Name}' in service '{service.Name}' validation failed." + Environment.NewLine +
                             string.Join(Environment.NewLine, results.Select(r => r.ErrorMessage)));
                     }
-                    
+
                     // right now only http is supported, so it must be set
                     if (probe.Probe!.Http == null)
                     {
                         throw new TyeYamlException(CoreStrings.FormatProberRequired(probe.Name));
                     }
-                    
+
                     context = new ValidationContext(probe.Probe!.Http);
                     if (!Validator.TryValidateObject(probe.Probe!.Http, context, results, validateAllProperties: true))
                     {
@@ -160,7 +160,7 @@ namespace Microsoft.Tye.ConfigModel
                             $"Http in probe '{probe.Name}' in service '{service.Name}' validation failed." + Environment.NewLine +
                             string.Join(Environment.NewLine, results.Select(r => r.ErrorMessage)));
                     }
-                    
+
                     if (probe.Name == "liveness" && probe.Probe!.SuccessThreshold != 1)
                     {
                         throw new TyeYamlException(CoreStrings.FormatSuccessThresholdMustBeOne(probe.Name));

--- a/src/Microsoft.Tye.Hosting/ReplicaMonitor.cs
+++ b/src/Microsoft.Tye.Hosting/ReplicaMonitor.cs
@@ -230,19 +230,19 @@ namespace Microsoft.Tye.Hosting
 
             private void MoveToHealthy(ReplicaState from)
             {
-                _logger.LogDebug("Replica {name} is moving to an healthy state", _replica.Name);
+                _logger.LogInformation("Replica {name} is moving to an healthy state", _replica.Name);
                 ChangeState(ReplicaState.Healthy);
             }
 
             private void MoveToReady()
             {
-                _logger.LogDebug("Replica {name} is moving to a ready state", _replica.Name);
+                _logger.LogInformation("Replica {name} is moving to a ready state", _replica.Name);
                 ChangeState(ReplicaState.Ready);
             }
 
             private void Kill()
             {
-                _logger.LogDebug("Killing replica {name} because it has failed the liveness probe", _replica.Name);
+                _logger.LogInformation("Killing replica {name} because it has failed the liveness probe", _replica.Name);
 
                 // it is assumed that a `Started` replica should have an initialized stopping token source
                 _replica.StoppingTokenSource!.Cancel();
@@ -360,7 +360,7 @@ namespace Microsoft.Tye.Hosting
                     var res = await _httpClient.SendAsync(req, timeoutCts.Token);
                     if (!res.IsSuccessStatusCode)
                     {
-                        ShowWarning($"Replica {_replica.Name} failed http probe at address '{_httpProberSettings.Path}' due to a failed status ({res.StatusCode})");
+                        DebugWarning($"Replica {_replica.Name} failed http probe at address '{_httpProberSettings.Path}' due to a failed status ({res.StatusCode})");
                         Send(false);
                         return;
                     }
@@ -369,12 +369,12 @@ namespace Microsoft.Tye.Hosting
                 }
                 catch (HttpRequestException ex)
                 {
-                    ShowWarning($"Replica {_replica.Name} failed http probe at address '{_httpProberSettings.Path}' due to an http exception", ex);
+                    DebugWarning($"Replica {_replica.Name} failed http probe at address '{_httpProberSettings.Path}' due to an http exception", ex);
                     Send(false);
                 }
                 catch (TaskCanceledException)
                 {
-                    ShowWarning($"Replica {_replica.Name} failed http probe at address '{_httpProberSettings.Path}' due to timeout");
+                    DebugWarning($"Replica {_replica.Name} failed http probe at address '{_httpProberSettings.Path}' due to timeout");
                     Send(false);
                 }
                 finally
@@ -395,7 +395,7 @@ namespace Microsoft.Tye.Hosting
                 _lastStatus = status;
             }
 
-            private void ShowWarning(string message, Exception? ex = null)
+            private void DebugWarning(string message, Exception? ex = null)
             {
                 if (!_lastStatus)
                 {
@@ -404,11 +404,11 @@ namespace Microsoft.Tye.Hosting
 
                 if (ex != null)
                 {
-                    _logger.LogWarning(ex, message);
+                    _logger.LogDebug(ex, message);
                 }
                 else
                 {
-                    _logger.LogWarning(message);
+                    _logger.LogDebug(message);
                 }
             }
 

--- a/test/UnitTests/TyeDeserializationTests.cs
+++ b/test/UnitTests/TyeDeserializationTests.cs
@@ -537,7 +537,7 @@ services:
     - name: sample
       liveness:
         {field}: 3.5");
-            
+
             var exception = Assert.Throws<TyeYamlException>(() => parser.ParseConfigApplication());
             Assert.Contains(CoreStrings.FormatMustBeAnInteger(field), exception.Message);
         }
@@ -551,7 +551,7 @@ services:
     - name: sample
       liveness:
         {field}: -1");
-            
+
             var exception = Assert.Throws<TyeYamlException>(() => parser.ParseConfigApplication());
             Assert.Contains(CoreStrings.FormatMustBePositive(field), exception.Message);
         }
@@ -568,7 +568,7 @@ services:
     - name: sample
       liveness:
         {field}: 0");
-            
+
             var exception = Assert.Throws<TyeYamlException>(() => parser.ParseConfigApplication());
             Assert.Contains(CoreStrings.FormatMustBeGreaterThanZero(field), exception.Message);
         }
@@ -582,11 +582,11 @@ services:
       liveness:
         http:
             something: something");
-            
+
             var exception = Assert.Throws<TyeYamlException>(() => parser.ParseConfigApplication());
             Assert.Contains(CoreStrings.FormatUnrecognizedKey("something"), exception.Message);
         }
-        
+
         [Fact]
         public void Probe_HttpProber_PortMustBeScalar()
         {
@@ -596,7 +596,7 @@ services:
       liveness:
         http:
             port: 3.5");
-            
+
             var exception = Assert.Throws<TyeYamlException>(() => parser.ParseConfigApplication());
             Assert.Contains(CoreStrings.FormatMustBeAnInteger("port"), exception.Message);
         }
@@ -610,7 +610,7 @@ services:
       liveness:
         http:
             headers: abc");
-            
+
             var exception = Assert.Throws<TyeYamlException>(() => parser.ParseConfigApplication());
             Assert.Contains(CoreStrings.FormatExpectedYamlSequence("headers"), exception.Message);
         }
@@ -626,7 +626,7 @@ services:
             headers:
                 - name: header1
                   something: something");
-            
+
             var exception = Assert.Throws<TyeYamlException>(() => parser.ParseConfigApplication());
             Assert.Contains(CoreStrings.FormatUnrecognizedKey("something"), exception.Message);
         }

--- a/test/UnitTests/TyeDeserializationValidationTests.cs
+++ b/test/UnitTests/TyeDeserializationValidationTests.cs
@@ -241,5 +241,37 @@ services:
             var exception = Assert.Throws<TyeYamlException>(() => app.Validate());
             Assert.Contains(errorMessage, exception.Message);
         }
+        
+        [Fact]
+        public void ProberRequired()
+        {
+            var input = @"
+services:
+    - name: sample
+      liveness:
+        period: 1";
+            var errorMessage = CoreStrings.FormatProberRequired("liveness");
+            using var parser = new YamlParser(input);
+            var app = parser.ParseConfigApplication();
+            var exception = Assert.Throws<TyeYamlException>(() => app.Validate());
+            Assert.Contains(errorMessage, exception.Message);
+        }
+        
+        [Fact]
+        public void LivenessProbeSuccessThresholdMustBeOne()
+        {
+            var input = @"
+services:
+    - name: sample
+      liveness:
+        successThreshold: 2
+        http:
+            path: /";
+            var errorMessage = CoreStrings.FormatSuccessThresholdMustBeOne("liveness");
+            using var parser = new YamlParser(input);
+            var app = parser.ParseConfigApplication();
+            var exception = Assert.Throws<TyeYamlException>(() => app.Validate());
+            Assert.Contains(errorMessage, exception.Message);
+        }
     }
 }

--- a/test/UnitTests/TyeDeserializationValidationTests.cs
+++ b/test/UnitTests/TyeDeserializationValidationTests.cs
@@ -241,7 +241,7 @@ services:
             var exception = Assert.Throws<TyeYamlException>(() => app.Validate());
             Assert.Contains(errorMessage, exception.Message);
         }
-        
+
         [Fact]
         public void ProberRequired()
         {
@@ -256,7 +256,7 @@ services:
             var exception = Assert.Throws<TyeYamlException>(() => app.Validate());
             Assert.Contains(errorMessage, exception.Message);
         }
-        
+
         [Fact]
         public void LivenessProbeSuccessThresholdMustBeOne()
         {


### PR DESCRIPTION
## Changes

* Expanded the `schema.md` document to contain `liveness` and `readiness` configuration
* Added a sample project and a recipe 
* Added basic deserialization and validation tests
* Changed some logs in `ReplicaMonitor` to debug, and some logs to information. 

About the last point, If service has liveness/readiness with `initialDelay` of zero, when running `tye run` you will see some warnings, because it takes time for the service to start accepting requests.  

This is okay since the fact that the default for `failureThreshold` is 3 (and the minimum is 1) accounts for it.  

Still, no reason to show warning logs so I've changed these logs to Debug, and other logs that the user should see, to Information. 

Problem is that `tye run` shows debug logs, and there is no way to control it. 
Should I create a PR that makes the verbosity of the logs configurable?