### PR TITLE
log verbosity in tye run

### DIFF
--- a/docs/reference/commandline/tye-run.md
+++ b/docs/reference/commandline/tye-run.md
@@ -7,7 +7,7 @@
 ## Synopsis 
 
 ```text
-tye run [-?|-h|--help] [--no-build] [--port <port>] [--dtrace] [--debug][-f|--force] [<PATH>]
+tye run [-?|-h|--help] [--no-build] [--port <port>] [--dtrace] [--debug] [-f|--force] [-v|--verbosity <verbosity>] [<PATH>]
 ```
 
 ## Description
@@ -50,6 +50,17 @@ If a directory path is specified, `tye run` will default to using these files, i
 - `--debug <service>`
 
     Waits for debugger attach to service. Specify `*` to wait to attach to all services.
+
+- `--verbosity <verbosity>`
+
+    Sets the output verbosity of the process.  
+    Possible values are 
+    
+    * `debug` - display all logs that the process outputs
+    * `info` - display only informational logs
+    * `quiet` - display only warnings and errors
+
+    The default value is `info`
 
 ## Examples
 

--- a/src/Microsoft.Tye.Core/HostOptions.cs
+++ b/src/Microsoft.Tye.Core/HostOptions.cs
@@ -23,5 +23,7 @@ namespace Microsoft.Tye
         public bool NoBuild { get; set; }
 
         public int? Port { get; set; }
+
+        public Verbosity LogVerbosity { get; set; } = Verbosity.Debug;
     }
 }

--- a/src/Microsoft.Tye.Hosting/TyeHost.cs
+++ b/src/Microsoft.Tye.Hosting/TyeHost.cs
@@ -12,7 +12,6 @@ using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
@@ -112,8 +111,16 @@ namespace Microsoft.Tye.Hosting
             // Logging for this application
             builder.Host.UseSerilog((context, configuration) =>
             {
+                var logLevel = options.LogVerbosity switch
+                {
+                    Verbosity.Quiet => LogEventLevel.Warning,
+                    Verbosity.Info => LogEventLevel.Information,
+                    Verbosity.Debug => LogEventLevel.Verbose,
+                    _ => default
+                };
+                
                 configuration
-                    .MinimumLevel.Verbose()
+                    .MinimumLevel.Is(logLevel)
                     .Filter.ByExcluding(Matching.FromSource("Microsoft.AspNetCore"))
                     .Filter.ByExcluding(Matching.FromSource("Microsoft.Extensions"))
                     .Filter.ByExcluding(Matching.FromSource("Microsoft.Hosting"))
@@ -124,7 +131,7 @@ namespace Microsoft.Tye.Hosting
 
                 if (sink is object)
                 {
-                    configuration.WriteTo.Sink(sink, LogEventLevel.Verbose);
+                    configuration.WriteTo.Sink(sink, logLevel);
                 }
             });
 

--- a/src/Microsoft.Tye.Hosting/TyeHost.cs
+++ b/src/Microsoft.Tye.Hosting/TyeHost.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Tye.Hosting
                     Verbosity.Debug => LogEventLevel.Verbose,
                     _ => default
                 };
-                
+
                 configuration
                     .MinimumLevel.Is(logLevel)
                     .Filter.ByExcluding(Matching.FromSource("Microsoft.AspNetCore"))

--- a/src/tye/Program.RunCommand.cs
+++ b/src/tye/Program.RunCommand.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Tye
                     throw new CommandException("No project or solution file was found.");
                 }
 
-                var output = new OutputContext(args.Console, Verbosity.Info);
+                var output = new OutputContext(args.Console, args.Verbosity);
 
                 output.WriteInfoLine("Loading Application Details...");
                 var application = await ApplicationFactory.CreateAsync(output, args.Path);
@@ -103,6 +103,7 @@ namespace Microsoft.Tye
                     DistributedTraceProvider = args.Dtrace,
                     LoggingProvider = args.Logs,
                     MetricsProvider = args.Metrics,
+                    LogVerbosity = args.Verbosity
                 };
                 options.Debug.AddRange(args.Debug);
 
@@ -158,6 +159,8 @@ namespace Microsoft.Tye
             public FileInfo Path { get; set; } = default!;
 
             public int? Port { get; set; }
+
+            public Verbosity Verbosity { get; set; }
         }
     }
 }


### PR DESCRIPTION
We allow the user to specify the level of output verbosity when running `tye run`
The levels are 

* **Debug** - display all logs
* **Info** (Default) - display only info (or warn/error) logs
* **Quiet** - display only warn/error logs