### PR TITLE
Updated the reference to undeploy markdown file

### DIFF
--- a/docs/reference/commandline/README.md
+++ b/docs/reference/commandline/README.md
@@ -1,11 +1,11 @@
 # 📖 Tye commandline documentation
 
-| Topic | Description |
-|-------|-------------|
-|**[tye init](tye-init.md)** | Create a `tye.yaml`.
-|**[tye run](tye-run.md)** | Run an application locally.
-|**[tye build](tye-build.md)** | Build an application's containers.
-|**[tye push](tye-push.md)** | Push an application's containers.
-|**[tye deploy](tye-deploy.md)** | Deploy an application.
-|**[tye undeploy](tye-deploy.md)** | Remove a deployed application.
-|**[tye](tye.md)** | Base command.
+| Topic                               | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| **[tye init](tye-init.md)**         | Create a `tye.yaml`.               |
+| **[tye run](tye-run.md)**           | Run an application locally.        |
+| **[tye build](tye-build.md)**       | Build an application's containers. |
+| **[tye push](tye-push.md)**         | Push an application's containers.  |
+| **[tye deploy](tye-deploy.md)**     | Deploy an application.             |
+| **[tye undeploy](tye-undeploy.md)** | Remove a deployed application.     |
+| **[tye](tye.md)**                   | Base command.                      |


### PR DESCRIPTION
The commandline readme markdown file was pointing to a wrong link. Updated the link for Undeploy to point to the correct Tye-undeploy.md markdown file.