### PR TITLE
Actually call dotnet run with watch

### DIFF
--- a/src/Microsoft.Tye.Core/ProcessSpec.cs
+++ b/src/Microsoft.Tye.Core/ProcessSpec.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Tye
         public IDictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string>();
         public string? Arguments { get; set; }
         public Action<string>? OutputData { get; set; }
-        public Func<Task>? Build { get; set; }
+        public Func<Task<int>>? Build { get; set; }
         public Action<string>? ErrorData { get; set; }
         public Action<int>? OnStart { get; set; }
         public string? ShortDisplayName()

--- a/src/Microsoft.Tye.Core/ProcessSpec.cs
+++ b/src/Microsoft.Tye.Core/ProcessSpec.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Tye
         public Func<Task<int>>? Build { get; set; }
         public Action<string>? ErrorData { get; set; }
         public Action<int>? OnStart { get; set; }
+        public Action<int>? OnStop { get; set; }
         public string? ShortDisplayName()
             => Path.GetFileNameWithoutExtension(Executable);
     }

--- a/src/Microsoft.Tye.Core/ProcessSpec.cs
+++ b/src/Microsoft.Tye.Core/ProcessSpec.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Microsoft.Tye
 {
@@ -16,6 +17,7 @@ namespace Microsoft.Tye
         public IDictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string>();
         public string? Arguments { get; set; }
         public Action<string>? OutputData { get; set; }
+        public Func<Task>? Build { get; set; }
         public Action<string>? ErrorData { get; set; }
         public Action<int>? OnStart { get; set; }
         public string? ShortDisplayName()

--- a/src/Microsoft.Tye.Core/ProcessUtil.cs
+++ b/src/Microsoft.Tye.Core/ProcessUtil.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Tye
             Action<string>? outputDataReceived = null,
             Action<string>? errorDataReceived = null,
             Action<int>? onStart = null,
+            Action<int>? onStop = null,
             CancellationToken cancellationToken = default)
         {
             using var process = new Process()
@@ -136,12 +137,14 @@ namespace Microsoft.Tye
                 }
             }
 
-            return await processLifetimeTask.Task;
+            var processResult = await processLifetimeTask.Task;
+            onStop?.Invoke(processResult.ExitCode);
+            return processResult;
         }
 
         public static Task<ProcessResult> RunAsync(ProcessSpec processSpec, CancellationToken cancellationToken = default, bool throwOnError = true)
         {
-            return RunAsync(processSpec.Executable!, processSpec.Arguments!, processSpec.WorkingDirectory, throwOnError: throwOnError, processSpec.EnvironmentVariables, processSpec.OutputData, processSpec.ErrorData, processSpec.OnStart, cancellationToken);
+            return RunAsync(processSpec.Executable!, processSpec.Arguments!, processSpec.WorkingDirectory, throwOnError: throwOnError, processSpec.EnvironmentVariables, processSpec.OutputData, processSpec.ErrorData, processSpec.OnStart, processSpec.OnStop, cancellationToken);
         }
 
         public static void KillProcess(int pid)

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -304,6 +304,8 @@ namespace Microsoft.Tye.Hosting
                         if (_options.Watch && service.Description.RunInfo is ProjectRunInfo runInfo)
                         {
                             var projectFile = runInfo.ProjectFile.FullName;
+                            processInfo.Executable = "dotnet";
+                            processInfo.Arguments = $"run {service.Status.ProjectFilePath} --no-launch-profile {processInfo.Arguments}";
 
                             var fileSetFactory = new MsBuildFileSetFactory(_logger,
                                 projectFile,

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Tye.Hosting
                         }
                     }
 
-                  
+
                 }
             }
 

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -302,6 +302,11 @@ namespace Microsoft.Tye.Hosting
                             Build = async () =>
                             {
                                 var buildResult = await ProcessUtil.RunAsync("dotnet", $"build \"{service.Status.ProjectFilePath}\" /nologo", throwOnError: false, workingDirectory: application.ContextDirectory);
+                                if (buildResult.ExitCode != 0)
+                                {
+                                    _logger.LogInformation("Building projects failed with exit code {ExitCode}: \r\n" + buildResult.StandardOutput, buildResult.ExitCode);
+                                }
+                                return buildResult.ExitCode;
                             }
                         };
 

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -298,15 +298,16 @@ namespace Microsoft.Tye.Hosting
 
                                 WriteReplicaToStore(pid.ToString());
                                 service.ReplicaEvents.OnNext(new ReplicaEvent(ReplicaState.Started, status));
+                            },
+                            Build = async () =>
+                            {
+                                var buildResult = await ProcessUtil.RunAsync("dotnet", $"build \"{service.Status.ProjectFilePath}\" /nologo", throwOnError: false, workingDirectory: application.ContextDirectory);
                             }
                         };
 
                         if (_options.Watch && service.Description.RunInfo is ProjectRunInfo runInfo)
                         {
                             var projectFile = runInfo.ProjectFile.FullName;
-                            processInfo.Executable = "dotnet";
-                            processInfo.Arguments = $"run {service.Status.ProjectFilePath} --no-launch-profile {processInfo.Arguments}";
-
                             var fileSetFactory = new MsBuildFileSetFactory(_logger,
                                 projectFile,
                                 waitOnError: true,

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -244,7 +244,6 @@ namespace Microsoft.Tye.Hosting
 
                     if (!_options.Watch)
                     {
-                        // 
                         service.Replicas[replica] = status;
                         service.ReplicaEvents.OnNext(new ReplicaEvent(ReplicaState.Added, status));
                     }

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -361,7 +361,7 @@ namespace Microsoft.Tye.Hosting
                         }
                         else
                         {
-                            var result = await ProcessUtil.RunAsync(processInfo, status.StoppingTokenSource.Token, throwOnError: false);
+                            await ProcessUtil.RunAsync(processInfo, status.StoppingTokenSource.Token, throwOnError: false);
                         }
                     }
                     catch (Exception ex)

--- a/src/Microsoft.Tye.Hosting/Watch/DotNetWatcher.cs
+++ b/src/Microsoft.Tye.Hosting/Watch/DotNetWatcher.cs
@@ -95,6 +95,11 @@ namespace Microsoft.DotNet.Watcher
                     {
                         _logger.LogInformation($"watch: File changed: {fileSetTask.Result}");
                     }
+
+                    if (processSpec.Build != null)
+                    {
+                        await processSpec.Build();
+                    }
                 }
             }
         }

--- a/src/Microsoft.Tye.Hosting/Watch/DotNetWatcher.cs
+++ b/src/Microsoft.Tye.Hosting/Watch/DotNetWatcher.cs
@@ -98,7 +98,17 @@ namespace Microsoft.DotNet.Watcher
 
                     if (processSpec.Build != null)
                     {
-                        await processSpec.Build();
+                        while (true)
+                        {
+                            var exitCode = await processSpec.Build();
+                            if (exitCode == 0)
+                            {
+                                break;
+                                // Build failed, keep retrying builds until successful build. 
+                            }
+
+                            await fileSetWatcher.GetChangedFileAsync(cancellationToken, () => _logger.LogWarning("Waiting for a file to change before restarting dotnet..."));
+                        }
                     }
                 }
             }

--- a/src/Microsoft.Tye.Hosting/Watch/DotNetWatcher.cs
+++ b/src/Microsoft.Tye.Hosting/Watch/DotNetWatcher.cs
@@ -31,6 +31,11 @@ namespace Microsoft.DotNet.Watcher
 
             while (true)
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 processSpec.EnvironmentVariables["DOTNET_WATCH_ITERATION"] = iteration.ToString(CultureInfo.InvariantCulture);
                 iteration++;
 
@@ -39,11 +44,6 @@ namespace Microsoft.DotNet.Watcher
                 if (fileSet == null)
                 {
                     _logger.LogError("watch: Failed to find a list of files to watch");
-                    return;
-                }
-
-                if (cancellationToken.IsCancellationRequested)
-                {
                     return;
                 }
 

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -291,7 +291,7 @@ namespace E2ETest
                         return;
                     }
 
-                    await Task.Delay(500);
+                    await Task.Delay(5000);
                 }
 
                 throw new Exception("Failed to relaunch project with dotnet watch");


### PR DESCRIPTION
Prior, we would detect that the project needed to be rebuild, however we didn't actually rebuild the project as we just keep on running the executable. This was due to a bad refactor at the end of the feature.