### PR TITLE
supporting the components-path via dapr extension 

### DIFF
--- a/samples/dapr/orders/orders.csproj
+++ b/samples/dapr/orders/orders.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="0.6.0-preview01" />
+    <PackageReference Include="Dapr.AspNetCore" Version="0.8.0-preview01" />
   </ItemGroup>
 
 </Project>

--- a/samples/dapr/products/products.csproj
+++ b/samples/dapr/products/products.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="0.6.0-preview01" />
+    <PackageReference Include="Dapr.AspNetCore" Version="0.8.0-preview01" />
   </ItemGroup>
 
 </Project>

--- a/samples/dapr/store/store.csproj
+++ b/samples/dapr/store/store.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="0.6.0-preview01" />
+    <PackageReference Include="Dapr.AspNetCore" Version="0.8.0-preview01" />
   </ItemGroup>
   
 </Project>

--- a/samples/dapr/tye.yaml
+++ b/samples/dapr/tye.yaml
@@ -14,9 +14,11 @@ extensions:
   # config allows you to pass additional configuration into the dapr sidecar
   # config will be interpreted as a named k8s resource when deployed, and will be interpreted as
   # a file on disk when running locally at `./components/myconfig.yaml`
-  #
+  # 
   # config: myconfig
-  
+
+  # components-path configures the components path of the dapr sidecard
+  components-path: "./components/"
 services:
 - name: orders
   project: orders/orders.csproj
@@ -33,3 +35,10 @@ services:
   image: redis
   bindings: 
   - port: 6379
+# To ensure that your are running a dapr placement container with the right binding port.
+# (50005 as HostPort)
+- name: placement
+  image: daprio/dapr
+  args: ./placement
+  bindings:
+    - port: 50005

--- a/samples/dapr/tye.yaml
+++ b/samples/dapr/tye.yaml
@@ -14,7 +14,7 @@ extensions:
   # config allows you to pass additional configuration into the dapr sidecar
   # config will be interpreted as a named k8s resource when deployed, and will be interpreted as
   # a file on disk when running locally at `./components/myconfig.yaml`
-  # 
+  #
   # config: myconfig
 
   # components-path configures the components path of the dapr sidecard

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Tye.Extensions.Dapr
                     }
 
                     // See https://github.com/dotnet/tye/issues/260
-                    // 
+                    //
                     // Currently the pub-sub pattern does not work when you have multiple replicas. Each
                     // daprd instance expects that it has a single application to talk to. So if you're using
                     // pub-sub this means that you'll won't get some messages.
@@ -70,7 +70,7 @@ namespace Microsoft.Tye.Extensions.Dapr
                     {
                         proxy.Args += $" -log-level {logLevel}";
                     }
-                    
+
                     if (config.Data.TryGetValue("components-path", out obj) && obj?.ToString() is string componentsPath)
                     {
                         proxy.Args += $" -components-path {componentsPath}";

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -70,7 +70,11 @@ namespace Microsoft.Tye.Extensions.Dapr
                     {
                         proxy.Args += $" -log-level {logLevel}";
                     }
-
+                    
+                    if (config.Data.TryGetValue("components-path", out obj) && obj?.ToString() is string componentsPath)
+                    {
+                        proxy.Args += $" -components-path {componentsPath}";
+                    }
                     // Add dapr proxy as a service available to everyone.
                     proxy.Dependencies.UnionWith(context.Application.Services.Select(s => s.Name));
 


### PR DESCRIPTION
Add components-path to dapr extension to be able to change default dapr components-path. 
Closes #555 