### PR TITLE
Setup default RunCommand in case MSBuild project RunCommand is undefined

### DIFF
--- a/src/Microsoft.Tye.Core/ProjectReader.cs
+++ b/src/Microsoft.Tye.Core/ProjectReader.cs
@@ -240,6 +240,12 @@ namespace Microsoft.Tye
             // Figure out if functions app.
             // If so, run app with function host.
             project.RunCommand = projectInstance.GetPropertyValue("RunCommand");
+            if (string.IsNullOrEmpty(project.RunCommand) && projectInstance.GetPropertyValue("OutputType")?.ToLower() == "exe")
+            {
+                var outputPath = Path.Combine(Directory.GetCurrentDirectory(), projectInstance.GetPropertyValue("OutputPath"), project.TargetFrameworks[0], $"{projectInstance.GetPropertyValue("AssemblyName")}.exe");
+                project.RunCommand = Path.GetFullPath(new Uri(outputPath).LocalPath);
+            }
+
             project.RunArguments = projectInstance.GetPropertyValue("RunArguments");
             project.TargetPath = projectInstance.GetPropertyValue("TargetPath");
             project.PublishDir = projectInstance.GetPropertyValue("PublishDir");


### PR DESCRIPTION
Sometimes a project RunCommand can't be resolved

![image](https://user-images.githubusercontent.com/1785664/88461011-7ac9ee80-ce6e-11ea-8361-22b7d78da993.png)

Such situation causes that process launch failed.

![image](https://user-images.githubusercontent.com/1785664/88461176-60dcdb80-ce6f-11ea-8451-60469bac73bf.png)

