### PR TITLE
Basic clear logs button

### DIFF
--- a/src/Microsoft.Tye.Hosting/Dashboard/Pages/Logs.razor
+++ b/src/Microsoft.Tye.Hosting/Dashboard/Pages/Logs.razor
@@ -10,6 +10,9 @@
 }
 else
 {
+    <div>
+        <button type="button" class="btn btn-primary" @onclick=ClearLogs>Clear Log</button>
+    </div>
     <div style="overflow-y: scroll;position: absolute;height: 84%; width:75%; color:white;background-color:black;padding:10px">
         @foreach (var log in ApplicationLogs)
         {
@@ -46,6 +49,14 @@ else
         }
 
         base.OnInitialized();
+    }
+
+    private void ClearLogs()
+    {
+        InvokeAsync(() => {
+            ApplicationLogs?.Clear();
+            StateHasChanged();
+        });
     }
 
     void IDisposable.Dispose()

--- a/src/Microsoft.Tye.Hosting/Dashboard/Pages/Logs.razor
+++ b/src/Microsoft.Tye.Hosting/Dashboard/Pages/Logs.razor
@@ -10,7 +10,7 @@
 }
 else
 {
-    <div>
+    <div style="padding:10px">
         <button type="button" class="btn btn-primary" @onclick=ClearLogs>Clear Log</button>
     </div>
     <div style="overflow-y: scroll;position: absolute;height: 84%; width:75%; color:white;background-color:black;padding:10px">
@@ -53,10 +53,7 @@ else
 
     private void ClearLogs()
     {
-        InvokeAsync(() => {
-            ApplicationLogs?.Clear();
-            StateHasChanged();
-        });
+        ApplicationLogs?.Clear();
     }
 
     void IDisposable.Dispose()


### PR DESCRIPTION
When doing `the run --watch` the other day we noticed you quickly ended up with a log full of stuff that could get in the way.

I threw a clear button onto my dashboard and thought I'd do a PR to discuss it. @JunTaoLuo seemed hesitant when we brought it up, did you want something that could clear the current screen and bring it back later if you cleared by mistake or something? Personally I think this seems fine as you aren't playing with prod logs, just try to debug problems.

I can style it better if we decide to merge it. Something that occurred to me as I thought about this was that perhaps we should have a collapsed checkbook list at the top that lets you select other services to display logs for. Like a poor mans/quick trace view without setting up proper distributed tracing. Interleaving the logs on this screen.

<img width="1188" alt="Screen Shot 2020-07-28 at 1 28 45 PM" src="https://user-images.githubusercontent.com/234688/88718951-62104180-d0d7-11ea-811f-609823f3663b.png">
