### PR TITLE
fix header typo

### DIFF
--- a/docs/reference/commandline/tye-push.md
+++ b/docs/reference/commandline/tye-push.md
@@ -1,4 +1,4 @@
-# tye deploy
+# tye push
 
 ## Name
 


### PR DESCRIPTION
This file is "tye push", but a header text was "tye deploy".