### PR TITLE
Wrap certificateFilePath with double quotation marks

### DIFF
--- a/src/Microsoft.Tye.Hosting/TransformProjectsIntoContainers.cs
+++ b/src/Microsoft.Tye.Hosting/TransformProjectsIntoContainers.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Tye.Hosting
                 // We export the developer certificate from this machine
                 var certPassword = Guid.NewGuid().ToString();
                 var certificateDirectory = _certificateDirectory.Value;
-                var certificateFilePath = Path.Combine(certificateDirectory.DirectoryPath, project.AssemblyName + ".pfx");
+                var certificateFilePath = Path.Combine("\"" + certificateDirectory.DirectoryPath, project.AssemblyName + ".pfx\"");
                 await ProcessUtil.RunAsync("dotnet", $"dev-certs https -ep {certificateFilePath} -p {certPassword}");
                 serviceDescription.Configuration.Add(new EnvironmentVariable("Kestrel__Certificates__Development__Password", certPassword));
 

--- a/src/Microsoft.Tye.Hosting/TransformProjectsIntoContainers.cs
+++ b/src/Microsoft.Tye.Hosting/TransformProjectsIntoContainers.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Tye.Hosting
                 // We export the developer certificate from this machine
                 var certPassword = Guid.NewGuid().ToString();
                 var certificateDirectory = _certificateDirectory.Value;
-                var certificateFilePath = Path.Combine("\"" + certificateDirectory.DirectoryPath, project.AssemblyName + ".pfx\"");
+                var certificateFilePath = Path.Combine($"\"{certificateDirectory.DirectoryPath}", $"{project.AssemblyName}.pfx\"");
                 await ProcessUtil.RunAsync("dotnet", $"dev-certs https -ep {certificateFilePath} -p {certPassword}");
                 serviceDescription.Configuration.Add(new EnvironmentVariable("Kestrel__Certificates__Development__Password", certPassword));
 


### PR DESCRIPTION
Fixes #635 
when exporting developer certificate from the Windows machine when the current logged in user's username contains space.
The submitted fix doesn't have a test. I'm not sure how to mock the environment to simulate a Windows machine with a space username.

