### PR TITLE
Fixed unquoted file paths

### DIFF
--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Tye
                                 throw new CommandException($"Cannot clone repository {configService.Repository} because git is not installed. Please install git if you'd like to use \"repository\" in tye.yaml.");
                             }
 
-                            var result = await ProcessUtil.RunAsync("git", $"clone {configService.Repository} {clonePath}", workingDirectory: path, throwOnError: false);
+                            var result = await ProcessUtil.RunAsync("git", $"clone {configService.Repository} \"{clonePath}\"", workingDirectory: path, throwOnError: false);
 
                             if (result.ExitCode != 0)
                             {

--- a/src/Microsoft.Tye.Hosting/DockerRunner.cs
+++ b/src/Microsoft.Tye.Hosting/DockerRunner.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Tye.Hosting
                     }
                 }
 
-                var command = $"run -d {workingDirectory} {volumes} {environmentArguments} {portString} --name {replica} --restart=unless-stopped {dockerImage} {docker.Args ?? ""}";
+                var command = $"run -d \"{workingDirectory}\" {volumes} {environmentArguments} {portString} --name {replica} --restart=unless-stopped {dockerImage} {docker.Args ?? ""}";
 
                 _logger.LogInformation("Running image {Image} for {Replica}", docker.Image, replica);
 

--- a/src/Microsoft.Tye.Hosting/TransformProjectsIntoContainers.cs
+++ b/src/Microsoft.Tye.Hosting/TransformProjectsIntoContainers.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Tye.Hosting
                 var certPassword = Guid.NewGuid().ToString();
                 var certificateDirectory = _certificateDirectory.Value;
                 var certificateFilePath = Path.Combine(certificateDirectory.DirectoryPath, project.AssemblyName + ".pfx");
-                await ProcessUtil.RunAsync("dotnet", $"dev-certs https -ep {certificateFilePath} -p {certPassword}");
+                await ProcessUtil.RunAsync("dotnet", $"dev-certs https -ep \"{certificateFilePath}\" -p {certPassword}");
                 serviceDescription.Configuration.Add(new EnvironmentVariable("Kestrel__Certificates__Development__Password", certPassword));
 
                 // Certificate Path: https://github.com/dotnet/aspnetcore/blob/a9d702624a02ad4ebf593d9bf9c1c69f5702a6f5/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs#L419


### PR DESCRIPTION
Found and fixed two more cases of commands executed with an unquoted file path leading to problems with spaces in the path (see issue #647). The following commands were fixed:
* Parameter working directory when calling docker run.
* Parameter clone directory when calling git clone.