### PR TITLE
Improve nginx-ingress experience

### DIFF
--- a/samples/dockercompose/ingress.yml
+++ b/samples/dockercompose/ingress.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-basic

--- a/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
+++ b/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
@@ -62,36 +62,37 @@ namespace Microsoft.Tye
             output.WriteInfoLine($"Deployed application '{application.Name}'.");
             if (application.Ingress.Count > 0)
             {
-                foreach(var ingress in application.Ingress)
+                foreach (var ingress in application.Ingress)
                 {
                     using var ingressStep = output.BeginStep($"Retrieving details for {ingress.Name}...");
 
                     var done = false;
 
-                    Action<string> complete = line => {
+                    Action<string> complete = line =>
+                    {
                         done = line != "''";
-                        if(done) 
+                        if (done)
                         {
                             output.WriteInfoLine($"IngressIP: {line}");
                         }
                     };
 
                     var retries = 0;
-                    while(!done && retries < 60)
+                    while (!done && retries < 60)
                     {
                         var ingressExitCode = await Process.ExecuteAsync(
                             "kubectl", 
-                            $"get ingress {ingress.Name} -o jsonpath='{{..ip}}'", 
+                            $"get ingress {ingress.Name} -o jsonpath='{{..ip}}'",
                             System.Environment.CurrentDirectory,
                             complete,
                             capture.StdErr);
 
-                        if(ingressExitCode != 0)
+                        if (ingressExitCode != 0)
                         {
                             throw new CommandException("'kubectl get ingress' failed");
                         }
                         
-                        if(!done)
+                        if (!done)
                         {
                             await Task.Delay(1000);
                             retries++;

--- a/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
+++ b/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
@@ -60,44 +60,44 @@ namespace Microsoft.Tye
             }
 
             output.WriteInfoLine($"Deployed application '{application.Name}'.");
-            if(application.Ingress.Count > 0)
+            if (application.Ingress.Count > 0)
             {
-                    foreach(var ingress in application.Ingress)
-                    {
-                        using var ingressStep = output.BeginStep($"Retrieving details for {ingress.Name}...");
+                foreach(var ingress in application.Ingress)
+                {
+                    using var ingressStep = output.BeginStep($"Retrieving details for {ingress.Name}...");
 
-                        var done = false;
+                    var done = false;
 
-                        Action<string> complete = line => {
-                            done = line != "''";
-                            if(done) 
-                            {
-                                output.WriteInfoLine($"IngressIP: {line}");
-                            }
-                        };
-
-                        var retries = 0;
-                        while(!done && retries < 60)
+                    Action<string> complete = line => {
+                        done = line != "''";
+                        if(done) 
                         {
-                            var ingressExitCode = await Process.ExecuteAsync(
-                                "kubectl", 
-                                $"get ingress {ingress.Name} -o jsonpath='{{..ip}}'", 
-                                System.Environment.CurrentDirectory,
-                                complete,
-                                capture.StdErr);
+                            output.WriteInfoLine($"IngressIP: {line}");
+                        }
+                    };
 
-                            if(ingressExitCode != 0)
-                            {
-                                throw new CommandException("'kubectl get ingress' failed");
-                            }
-                            
-                            if(!done)
-                            {
-                                await Task.Delay(1000);
-                                retries++;
-                            }
-                        } 
-                    }
+                    var retries = 0;
+                    while(!done && retries < 60)
+                    {
+                        var ingressExitCode = await Process.ExecuteAsync(
+                            "kubectl", 
+                            $"get ingress {ingress.Name} -o jsonpath='{{..ip}}'", 
+                            System.Environment.CurrentDirectory,
+                            complete,
+                            capture.StdErr);
+
+                        if(ingressExitCode != 0)
+                        {
+                            throw new CommandException("'kubectl get ingress' failed");
+                        }
+                        
+                        if(!done)
+                        {
+                            await Task.Delay(1000);
+                            retries++;
+                        }
+                    } 
+                }
             }
         }
     }

--- a/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
+++ b/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Tye
                         var ingressExitCode = await Process.ExecuteAsync(
                             "kubectl",
                             $"get ingress {ingress.Name} -o jsonpath='{{..ip}}'",
-                            System.Environment.CurrentDirectory,
+                            Environment.CurrentDirectory,
                             complete,
                             capture.StdErr);
 

--- a/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
+++ b/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Tye
             output.WriteInfoLine($"Deployed application '{application.Name}'.");
             if (application.Ingress.Count > 0)
             {
+                output.WriteInfoLine($"Waiting for ingress to be deployed. This may take a long time.");
                 foreach (var ingress in application.Ingress)
                 {
                     using var ingressStep = output.BeginStep($"Retrieving details for {ingress.Name}...");
@@ -94,7 +95,7 @@ namespace Microsoft.Tye
 
                         if (!done)
                         {
-                            await Task.Delay(1000);
+                            await Task.Delay(2000);
                             retries++;
                         }
                     }

--- a/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
+++ b/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Tye
                     while (!done && retries < 60)
                     {
                         var ingressExitCode = await Process.ExecuteAsync(
-                            "kubectl", 
+                            "kubectl",
                             $"get ingress {ingress.Name} -o jsonpath='{{..ip}}'",
                             System.Environment.CurrentDirectory,
                             complete,
@@ -91,13 +91,13 @@ namespace Microsoft.Tye
                         {
                             throw new CommandException("'kubectl get ingress' failed");
                         }
-                        
+
                         if (!done)
                         {
                             await Task.Delay(1000);
                             retries++;
                         }
-                    } 
+                    }
                 }
             }
         }

--- a/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
+++ b/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.CommandLine.Invocation;
 using System.IO;
 using System.Text;
@@ -15,7 +16,7 @@ namespace Microsoft.Tye
 
         public override async Task ExecuteAsync(OutputContext output, ApplicationBuilder application)
         {
-            using var step = output.BeginStep("");
+            using var step = output.BeginStep("Applying Kubernetes Manifests...");
 
             if (!await KubectlDetector.IsKubectlInstalledAsync(output))
             {
@@ -59,6 +60,45 @@ namespace Microsoft.Tye
             }
 
             output.WriteInfoLine($"Deployed application '{application.Name}'.");
+            if(application.Ingress.Count > 0)
+            {
+                    foreach(var ingress in application.Ingress)
+                    {
+                        using var ingressStep = output.BeginStep($"Retrieving details for {ingress.Name}...");
+
+                        var done = false;
+
+                        Action<string> complete = line => {
+                            done = line != "''";
+                            if(done) 
+                            {
+                                output.WriteInfoLine($"IngressIP: {line}");
+                            }
+                        };
+
+                        var retries = 0;
+                        while(!done && retries < 60)
+                        {
+                            var ingressExitCode = await Process.ExecuteAsync(
+                                "kubectl", 
+                                $"get ingress {ingress.Name} -o jsonpath='{{..ip}}'", 
+                                System.Environment.CurrentDirectory,
+                                complete,
+                                capture.StdErr);
+
+                            if(ingressExitCode != 0)
+                            {
+                                throw new CommandException("'kubectl get ingress' failed");
+                            }
+                            
+                            if(!done)
+                            {
+                                await Task.Delay(1000);
+                                retries++;
+                            }
+                        } 
+                    }
+            }
         }
     }
 }

--- a/test/E2ETest/testassets/generate/apps-with-ingress.yaml
+++ b/test/E2ETest/testassets/generate/apps-with-ingress.yaml
@@ -125,7 +125,7 @@ spec:
 ...
 ---
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: ingress
   annotations:

--- a/test/E2ETest/testassets/generate/apps-with-ingress.yaml
+++ b/test/E2ETest/testassets/generate/apps-with-ingress.yaml
@@ -138,25 +138,37 @@ spec:
   - http:
       paths:
       - backend:
-          serviceName: appa
-          servicePort: 80
+          service:
+            name: appa
+            port:
+              number: 80
         path: /A(/|$)(.*)
+        pathType: Prefix
       - backend:
-          serviceName: appb
-          servicePort: 80
+          service:
+            name: appb
+            port:
+              number: 80
         path: /B(/|$)(.*)
+        pathType: Prefix
   - host: a.example.com
     http:
       paths:
       - backend:
-          serviceName: appa
-          servicePort: 80
+          service:
+            name: appa
+            port:
+              number: 80
         path: /()(.*)
+        pathType: Prefix
   - host: b.example.com
     http:
       paths:
       - backend:
-          serviceName: appb
-          servicePort: 80
+          service:
+            name: appb
+            port:
+              number: 80
         path: /()(.*)
+        pathType: Prefix
 ...


### PR DESCRIPTION
I wanted to investigate the bugs I heard about ingress not working after an undeploy/deploy and look at reporting the ingress IPs after deploying with ingress. 

Running this code showed me that after deploying it can take a while to actually assign an IP. K8s docs say it can take "up to a minute or two". So I am thinking we want to wait for it to take and maybe show some progress when running in interactive mode. We can put it in here like I have but I was thinking it seems like it's time to add a `StatusStep` to the end of `DeployCommand.cs` that has a set of things we check on and report after deployment has happened.

What do you think?