### PR TITLE
Use out-of-proc MSBuild evaluation

### DIFF
--- a/clean.cmd
+++ b/clean.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+SETLOCAL
+PowerShell -NoProfile -NoLogo -ExecutionPolicy ByPass -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = ''; try { & '%~dp0clean.ps1' %*; exit $LASTEXITCODE } catch { write-host $_; exit 1 }"

--- a/clean.ps1
+++ b/clean.ps1
@@ -1,0 +1,42 @@
+#requires -version 5
+
+<#
+.SYNOPSIS
+Clean this repository.
+
+.DESCRIPTION
+This script cleans this repository interactively, leaving downloaded infrastructure untouched.
+Clean operation is interactive to avoid losing new but unstaged files. Press 'c' then [Enter]
+to perform the proposed deletions.
+
+.EXAMPLE
+Perform default clean operation.
+
+    clean.ps1
+
+.EXAMPLE
+Clean everything but downloaded infrastructure and VS / VS Code folders.
+
+    clean.ps1 -e .vs/ -e .vscode/
+#>
+
+[CmdletBinding(PositionalBinding = $false)]
+param(
+    # Other lifecycle targets
+    [switch]$Help, # Show help
+
+    # Capture the rest
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$GitArguments
+)
+
+Set-StrictMode -Version 2
+$ErrorActionPreference = 'Stop'
+
+if ($Help) {
+    Get-Help $PSCommandPath
+    exit 0
+}
+
+git clean -dix -e .dotnet/ -e .tools/ @GitArguments
+git checkout -- $(git ls-files -d)

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+#
+# Functions
+#
+__usage() {
+    echo "Usage: $(basename "${BASH_SOURCE[0]}") <Arguments>
+
+Arguments:
+    <Arguments>...         Arguments passed to the 'git' command. Any number of arguments allowed.
+
+Description:
+    This script cleans the repository interactively, leaving downloaded infrastructure untouched.
+    Clean operation is interactive to avoid losing new but unstaged files. Press 'c' then [Enter]
+    to perform the proposed deletions.
+"
+}
+
+git_args=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -\?|-h|--help)
+            __usage
+            exit 0
+            ;;
+        *)
+            git_args[${#git_args[*]}]="$1"
+            ;;
+    esac
+    shift
+done
+
+# This incantation avoids unbound variable issues if git_args is empty
+# https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u
+git clean -dix -e .dotnet/ -e .tools/ ${git_args[@]+"${git_args[@]}"}

--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -135,7 +135,8 @@ namespace Microsoft.Tye
                     if (msbuildEvaluationResult.ExitCode != 0)
                     {
                         output.WriteDebugLine($"Evaluating project failed with exit code {msbuildEvaluationResult.ExitCode}:" +
-                            $"{Environment.NewLine}{msbuildEvaluationResult.StandardError}");
+                            $"{Environment.NewLine}Ouptut: {msbuildEvaluationResult.StandardOutput}" +
+                            $"{Environment.NewLine}Error: {msbuildEvaluationResult.StandardError}");
                     }
 
                     var msbuildEvaluationOutput = msbuildEvaluationResult

--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -121,12 +121,12 @@ namespace Microsoft.Tye
                     output.WriteDebugLine("Restoring and evaluating projects");
 
                     var msbuildEvaluationResult = await ProcessUtil.RunAsync(
-                        "dotnet", 
+                        "dotnet",
                         $"build " +
                             $"\"{projectPath}\" " +
                             $"/p:CustomAfterMicrosoftCommonTargets={Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "ProjectEvaluation.targets")} " +
-                            $"/nologo", 
-                        throwOnError: false, 
+                            $"/nologo",
+                        throwOnError: false,
                         workingDirectory: directory.DirectoryPath);
 
                     // If the build fails, we're not really blocked from doing our work.

--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -4,9 +4,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Tye.ConfigModel;
 
@@ -74,6 +77,87 @@ namespace Microsoft.Tye
                     config.Services.Where(filter.ServicesFilter).ToList() :
                     config.Services;
 
+                var sw = Stopwatch.StartNew();
+                // Project services will be restored and evaluated before resolving all other services.
+                // This batching will mitigate the performance cost of running MSBuild out of process.
+                var projectServices = services.Where(s => !string.IsNullOrEmpty(s.Project));
+                var projectMetadata = new Dictionary<string, string>();
+
+                using (var directory = TempDirectory.Create())
+                {
+                    var projectPath = Path.Combine(directory.DirectoryPath, Path.GetRandomFileName() + ".proj");
+
+                    var sb = new StringBuilder();
+                    sb.AppendLine("<Project>");
+                    sb.AppendLine("    <ItemGroup>");
+
+                    foreach (var project in projectServices)
+                    {
+                        var expandedProject = Environment.ExpandEnvironmentVariables(project.Project!);
+                        project.ProjectFullPath = Path.Combine(config.Source.DirectoryName!, expandedProject);
+
+                        if (!File.Exists(project.ProjectFullPath))
+                        {
+                            throw new CommandException($"Failed to locate project: '{project.ProjectFullPath}'.");
+                        }
+
+                        sb.AppendLine($"        <MicrosoftTye_ProjectServices " +
+                            $"Include=\"{project.ProjectFullPath}\" " +
+                            $"Name=\"{project.Name}\" " +
+                            $"BuildProperties=\"{(project.BuildProperties.Any() ? project.BuildProperties.Select(kvp => $"{kvp.Name}={kvp.Value}").Aggregate((a, b) => a + ";" + b) : string.Empty )}\" />");
+                    }
+                    sb.AppendLine(@"    </ItemGroup>");
+
+                    sb.AppendLine($@"    <Target Name=""MicrosoftTye_EvaluateProjects"">");
+                    sb.AppendLine($@"        <MsBuild Projects=""@(MicrosoftTye_ProjectServices)"" "
+                        + $@"Properties=""%(BuildProperties);"
+                        + $@"MicrosoftTye_ProjectName=%(Name)"" "
+                        + $@"Targets=""MicrosoftTye_GetProjectMetadata"" BuildInParallel=""true"" />");
+
+                    sb.AppendLine("    </Target>");
+                    sb.AppendLine("</Project>");
+                    File.WriteAllText(projectPath, sb.ToString());
+
+                    output.WriteDebugLine("Restoring and evaluating projects");
+
+                    var msbuildEvaluationResult = await ProcessUtil.RunAsync(
+                        "dotnet", 
+                        $"build " +
+                            $"\"{projectPath}\" " +
+                            $"/p:CustomAfterMicrosoftCommonTargets={Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "ProjectEvaluation.targets")} " +
+                            $"/nologo", 
+                        throwOnError: false, 
+                        workingDirectory: directory.DirectoryPath);
+
+                    // If the build fails, we're not really blocked from doing our work.
+                    // For now we just log the output to debug. There are errors that occur during
+                    // running these targets we don't really care as long as we get the data.
+                    if (msbuildEvaluationResult.ExitCode != 0)
+                    {
+                        output.WriteDebugLine($"Evaluating project failed with exit code {msbuildEvaluationResult.ExitCode}:" +
+                            $"{Environment.NewLine}{msbuildEvaluationResult.StandardError}");
+                    }
+
+                    var msbuildEvaluationOutput = msbuildEvaluationResult
+                        .StandardOutput
+                        .Split(Environment.NewLine);
+
+                    foreach (var line in msbuildEvaluationOutput)
+                    {
+                        if (line.Trim().StartsWith("Microsoft.Tye metadata: "))
+                        {
+                            var values = line.Split(':', 3);
+                            var projectName = values[1].Trim();
+                            var metadataPath = values[2].Trim();
+                            projectMetadata.Add(projectName, metadataPath);
+
+                            output.WriteDebugLine($"Resolved metadata for service {projectName} at {metadataPath}");
+                        }
+                    }
+
+                    output.WriteDebugLine($"Restore and project evaluation took: {sw.Elapsed.TotalMilliseconds}ms");
+                }
+
                 foreach (var configService in services)
                 {
                     ServiceBuilder service;
@@ -87,9 +171,7 @@ namespace Microsoft.Tye
 
                     if (!string.IsNullOrEmpty(configService.Project))
                     {
-                        var expandedProject = Environment.ExpandEnvironmentVariables(configService.Project);
-                        var projectFile = new FileInfo(Path.Combine(config.Source.DirectoryName!, expandedProject));
-                        var project = new DotnetProjectServiceBuilder(configService.Name!, projectFile);
+                        var project = new DotnetProjectServiceBuilder(configService.Name!, new FileInfo(configService.ProjectFullPath));
                         service = project;
 
                         project.Build = configService.Build ?? true;
@@ -107,7 +189,13 @@ namespace Microsoft.Tye
                         // to prompt for the registry name.
                         project.ContainerInfo = new ContainerInfo() { UseMultiphaseDockerfile = false, };
 
-                        await ProjectReader.ReadProjectDetailsAsync(output, project);
+                        // If project evaluation is successful this should not happen, therefore an exception will be thrown.
+                        if (!projectMetadata.ContainsKey(configService.Name))
+                        {
+                            throw new CommandException($"Evaluated project metadata file could not be found for service {configService.Name}");
+                        }
+
+                        ProjectReader.ReadProjectDetails(output, project, projectMetadata[configService.Name]);
 
                         // Do k8s by default.
                         project.ManifestInfo = new KubernetesManifestInfo();

--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Tye
                         sb.AppendLine($"        <MicrosoftTye_ProjectServices " +
                             $"Include=\"{project.ProjectFullPath}\" " +
                             $"Name=\"{project.Name}\" " +
-                            $"BuildProperties=\"{(project.BuildProperties.Any() ? project.BuildProperties.Select(kvp => $"{kvp.Name}={kvp.Value}").Aggregate((a, b) => a + ";" + b) : string.Empty )}\" />");
+                            $"BuildProperties=\"{(project.BuildProperties.Any() ? project.BuildProperties.Select(kvp => $"{kvp.Name}={kvp.Value}").Aggregate((a, b) => a + ";" + b) : string.Empty)}\" />");
                     }
                     sb.AppendLine(@"    </ItemGroup>");
 

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigService.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigService.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Tye.ConfigModel
         public Dictionary<string, string> DockerFileArgs { get; set; } = new Dictionary<string, string>();
         public string? DockerFileContext { get; set; }
         public string? Project { get; set; }
+        public string? ProjectFullPath { get; set; }
         public string? Include { get; set; }
         public string? Repository { get; set; }
         public bool? Build { get; set; }

--- a/src/Microsoft.Tye.Core/Microsoft.Tye.Core.csproj
+++ b/src/Microsoft.Tye.Core/Microsoft.Tye.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Tye</RootNamespace>
     <AssemblyName>Microsoft.Tye.Core</AssemblyName>
     <PackageId>Microsoft.Tye.Core</PackageId>

--- a/src/Microsoft.Tye.Core/ProjectReader.cs
+++ b/src/Microsoft.Tye.Core/ProjectReader.cs
@@ -137,7 +137,6 @@ namespace Microsoft.Tye
             var metadata = new Dictionary<string, string>();
 
             var msbuildArgs = "msbuild " +
-                "/t:Restore " +
                 "/t:MicrosoftTye_GetProjectMetadata " +
                 $"/p:CustomAfterMicrosoftCommonTargets=\"{Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "ProjectEvaluation.targets")}\" ";
             if (project.BuildProperties.Any())

--- a/src/Microsoft.Tye.Core/ProjectReader.cs
+++ b/src/Microsoft.Tye.Core/ProjectReader.cs
@@ -135,25 +135,9 @@ namespace Microsoft.Tye
             var sw = Stopwatch.StartNew();
 
             var metadata = new Dictionary<string, string>();
-            var restoreArgs = $"restore \"{project.ProjectFile.FullName}\" ";
-            if (project.BuildProperties.Any())
-            {
-                restoreArgs += $"{project.BuildProperties.Select(kvp => $"/p:{kvp.Key}={kvp.Value}").Aggregate((a, b) => a + " " + b)} ";
-            }
-            restoreArgs += "/nologo";
-            output.WriteDebugLine($"Running restore command: dotnet {restoreArgs}");
-
-            var restoreResult = await ProcessUtil.RunAsync("dotnet", restoreArgs, throwOnError: false);
-
-            // We don't really look at the result, because it's not clear we should halt totally
-            // if restore fails.
-            if (restoreResult.ExitCode != 0)
-            {
-                output.WriteDebugLine($"Project restored failed with exit code {restoreResult.ExitCode}:" +
-                    $"{Environment.NewLine}{restoreResult.StandardError}");
-            }
 
             var msbuildArgs = "msbuild " +
+                "/t:Restore " +
                 "/t:MicrosoftTye_GetProjectMetadata " +
                 $"/p:CustomAfterMicrosoftCommonTargets=\"{Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "ProjectEvaluation.targets")}\" ";
             if (project.BuildProperties.Any())

--- a/src/Microsoft.Tye.Core/ProjectReader.cs
+++ b/src/Microsoft.Tye.Core/ProjectReader.cs
@@ -155,9 +155,12 @@ namespace Microsoft.Tye
 
             var msbuildArgs = "msbuild " +
                 "/t:MicrosoftTye_GetProjectMetadata " +
-                $"/p:CustomAfterMicrosoftCommonTargets=\"{Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "ProjectEvaluation.targets")}\" " +
-                $"\"{project.ProjectFile.FullName}\" " +
-                "/nologo";
+                $"/p:CustomAfterMicrosoftCommonTargets=\"{Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "ProjectEvaluation.targets")}\" ";
+            if (project.BuildProperties.Any())
+            {
+                msbuildArgs += $"{project.BuildProperties.Select(kvp => $"/p:{kvp.Key}={kvp.Value}").Aggregate((a, b) => a + " " + b)} ";
+            }
+            msbuildArgs += $"\"{project.ProjectFile.FullName}\" /nologo";
 
             output.WriteDebugLine($"Running msbuild command: dotnet {msbuildArgs}");
 

--- a/src/Microsoft.Tye.Extensions/Microsoft.Tye.Extensions.csproj
+++ b/src/Microsoft.Tye.Extensions/Microsoft.Tye.Extensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Tye.Hosting.Diagnostics/Microsoft.Tye.Hosting.Diagnostics.csproj
+++ b/src/Microsoft.Tye.Hosting.Diagnostics/Microsoft.Tye.Hosting.Diagnostics.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Description>Diagnostics collector and exporter for .NET Core applications.</Description>
     <AssemblyName>Microsoft.Tye.Hosting.Diagnostics</AssemblyName>
     <PackageId>Microsoft.Tye.Hosting.Diagnostics</PackageId>

--- a/src/Microsoft.Tye.Hosting/Microsoft.Tye.Hosting.csproj
+++ b/src/Microsoft.Tye.Hosting/Microsoft.Tye.Hosting.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Description>Orchestration host APIs.</Description>
     <AssemblyName>Microsoft.Tye.Hosting</AssemblyName>
     <PackageId>Microsoft.Tye.Hosting</PackageId>
@@ -17,7 +17,7 @@
   <ItemGroup>
     <None Include="Watch\assets\**\*" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Bedrock.Framework" Version="0.1.38-alpha.gd25d5b37ad" />
     <PackageReference Include="FeatherHttp" Version="0.1.42-alpha.gf06a8747e7" />

--- a/src/tye-diag-agent/tye-diag-agent.csproj
+++ b/src/tye-diag-agent/tye-diag-agent.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Microsoft.Tye</RootNamespace>
   </PropertyGroup>
 

--- a/src/tye/ProjectEvaluation.targets
+++ b/src/tye/ProjectEvaluation.targets
@@ -1,0 +1,40 @@
+﻿<Project>
+    <Target Name="MicrosoftTye_GetProjectMetadata" DependsOnTargets="ResolveReferences;ResolvePackageDependenciesDesignTime;PrepareResources;GetAssemblyAttributes" >
+        <PropertyGroup>
+            <_MicrosoftTye_MetadataFile>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)MicrosoftTye.ProjectMetadata.txt'))</_MicrosoftTye_MetadataFile>
+            <_MicrosoftTye_ProjectFrameworkReference>@(FrameworkReference, '%3B')</_MicrosoftTye_ProjectFrameworkReference>
+        </PropertyGroup>
+
+        <ItemGroup>
+            <_MicrosoftTye_ProjectMetadata Include="AssemblyInformationalVersion: $(AssemblyInformationalVersion)" />
+            <_MicrosoftTye_ProjectMetadata Include="InformationalVersion: $(InformationalVersion)" />
+            <_MicrosoftTye_ProjectMetadata Include="Version: $(Version)" />
+            <_MicrosoftTye_ProjectMetadata Include="TargetFrameworks: $(TargetFrameworks)" />
+            <_MicrosoftTye_ProjectMetadata Include="RunCommand: $(RunCommand)" />
+            <_MicrosoftTye_ProjectMetadata Include="RunArguments: $(RunArguments)" />
+            <_MicrosoftTye_ProjectMetadata Include="TargetPath: $(TargetPath)" />
+            <_MicrosoftTye_ProjectMetadata Include="PublishDir: $(PublishDir)" />
+            <_MicrosoftTye_ProjectMetadata Include="AssemblyName: $(AssemblyName)" />
+            <_MicrosoftTye_ProjectMetadata Include="IntermediateOutputPath: $(IntermediateOutputPath)" />
+            <_MicrosoftTye_ProjectMetadata Include="TargetFramework: $(TargetFramework)" />
+            <_MicrosoftTye_ProjectMetadata Include="_ShortFrameworkIdentifier: $(_ShortFrameworkIdentifier)" />
+            <_MicrosoftTye_ProjectMetadata Include="_ShortFrameworkVersion: $(_ShortFrameworkVersion)" />
+            <_MicrosoftTye_ProjectMetadata Include="_TargetFrameworkVersionWithoutV: $(_TargetFrameworkVersionWithoutV)" />
+            <_MicrosoftTye_ProjectMetadata Include="FrameworkReference: $(_MicrosoftTye_ProjectFrameworkReference)" />
+            <_MicrosoftTye_ProjectMetadata Include="ContainerBaseImage: $(ContainerBaseImage)" />
+            <_MicrosoftTye_ProjectMetadata Include="ContainerBaseTag: $(ContainerBaseTag)" />
+            <_MicrosoftTye_ProjectMetadata Include="MicrosoftNETPlatformLibrary: $(MicrosoftNETPlatformLibrary)" />
+            <_MicrosoftTye_ProjectMetadata Include="_AspNetCoreAppSharedFxIsEnabled: $(_AspNetCoreAppSharedFxIsEnabled)" />
+            <_MicrosoftTye_ProjectMetadata Include="UsingMicrosoftNETSdkWeb: $(UsingMicrosoftNETSdkWeb)" />
+        </ItemGroup>
+
+        <WriteLinesToFile
+            File="$(_MicrosoftTye_MetadataFile)"
+            Lines="@(_MicrosoftTye_ProjectMetadata)"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true"/>
+
+        <Message Text="Microsoft.Tye metadata file: $(_MicrosoftTye_MetadataFile)" Importance="High"/>
+
+    </Target>
+</Project>

--- a/src/tye/ProjectEvaluation.targets
+++ b/src/tye/ProjectEvaluation.targets
@@ -34,7 +34,7 @@
             Overwrite="true"
             WriteOnlyWhenDifferent="true"/>
 
-        <Message Text="Microsoft.Tye metadata file: $(_MicrosoftTye_MetadataFile)" Importance="High"/>
+        <Message Text="Microsoft.Tye metadata: $(MicrosoftTye_ProjectName): $(_MicrosoftTye_MetadataFile)" Importance="High"/>
 
     </Target>
 </Project>

--- a/src/tye/ProjectEvaluation.targets
+++ b/src/tye/ProjectEvaluation.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
-    <Target Name="MicrosoftTye_GetProjectMetadata" DependsOnTargets="ResolveReferences;ResolvePackageDependenciesDesignTime;PrepareResources;GetAssemblyAttributes" >
+    <Target Name="MicrosoftTye_GetProjectMetadata" DependsOnTargets="Restore;ResolveReferences;ResolvePackageDependenciesDesignTime;PrepareResources;GetAssemblyAttributes" >
         <PropertyGroup>
             <_MicrosoftTye_MetadataFile>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)MicrosoftTye.ProjectMetadata.txt'))</_MicrosoftTye_MetadataFile>
             <_MicrosoftTye_ProjectFrameworkReference>@(FrameworkReference, '%3B')</_MicrosoftTye_ProjectFrameworkReference>

--- a/src/tye/tye.csproj
+++ b/src/tye/tye.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Microsoft.Tye</RootNamespace>
     <AssemblyName>tye</AssemblyName>
     <PackageId>Microsoft.Tye</PackageId>

--- a/src/tye/tye.csproj
+++ b/src/tye/tye.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="ProjectEvaluation.targets" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\shared\KubectlDetector.cs" Link="KubectlDetector.cs" />
     <Compile Include="..\shared\TempFile.cs" Link="TempFile.cs" />
   </ItemGroup>

--- a/test/E2ETest/ApplicationFactoryTests.cs
+++ b/test/E2ETest/ApplicationFactoryTests.cs
@@ -118,8 +118,8 @@ services:
             var exception = await Assert.ThrowsAsync<CommandException>(async () =>
                 await ApplicationFactory.CreateAsync(outputContext, projectFile));
 
-            var wrongProjectPath = Path.Combine(projectDirectory.DirectoryPath, "backend1");
-            Assert.Equal($"Failed to locate directory: '{wrongProjectPath}'.", exception.Message);
+            var wrongProjectPath = Path.Combine(projectDirectory.DirectoryPath, "backend1/backend.csproj");
+            Assert.Equal($"Failed to locate project: '{wrongProjectPath}'.", exception.Message);
         }
     }
 }

--- a/test/E2ETest/Microsoft.Tye.E2ETests.csproj
+++ b/test/E2ETest/Microsoft.Tye.E2ETests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Microsoft.Tye.E2ETest</AssemblyName>
     <IsTestProject>true</IsTestProject>
     <IsUnitTestProject>true</IsUnitTestProject>

--- a/test/Microsoft.Tye.Extensions.Configuration.Tests/Microsoft.Tye.Extensions.Configuration.Tests.csproj
+++ b/test/Microsoft.Tye.Extensions.Configuration.Tests/Microsoft.Tye.Extensions.Configuration.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/test/Test.Infrastructure/Test.Infrastructure.csproj
+++ b/test/Test.Infrastructure/Test.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <TestRunnerName>XUnit</TestRunnerName>
     <Nullable>disable</Nullable>

--- a/test/UnitTests/Microsoft.Tye.UnitTests.csproj
+++ b/test/UnitTests/Microsoft.Tye.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Microsoft.Tye.UnitTests</AssemblyName>
     <IsTestProject>true</IsTestProject>
     <IsUnitTestProject>true</IsUnitTestProject>


### PR DESCRIPTION
Fixes https://github.com/dotnet/tye/issues/594

I have tested to ensure that the original issue where installing a 5.0 SDK would break apps has been fixed with this change. With this change, supporting new TFMs wouldn't require tye itself to be re-targeted.

So far testing the perf with frontend-backend sample gives:

Before:
backend.csproj
Evaluation Took: 1500.9242ms
frontend.csproj
Evaluation Took: 463.2118ms

After:
backend.csproj
Evaluation Took: 1733.3304ms
frontend.csproj
Evaluation Took: 1766.8971ms

So there is a performance penalty with running out of proc, especially with additional projects.
