### PR TITLE
Set DAPR_HTTP_PORT when launching project

### DIFF
--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Tye.Extensions.Dapr
                     };
                     project.EnvironmentVariables.Add(daprGrpcPort);
 
-                    // Set DAPR_Http_PORT based on this service's assigned port
+                    // Set DAPR_HTTP_PORT based on this service's assigned port
                     var daprHttpPort = new EnvironmentVariableBuilder("DAPR_HTTP_PORT")
                     {
                         Source = new EnvironmentVariableSourceBuilder(proxy.Name, binding: "http")
@@ -148,6 +148,16 @@ namespace Microsoft.Tye.Extensions.Dapr
                         },
                     };
                     proxy.EnvironmentVariables.Add(daprHttpPort);
+
+                    // Add another copy of this envvar to the project.
+                    daprHttpPort = new EnvironmentVariableBuilder("DAPR_HTTP_PORT")
+                    {
+                        Source = new EnvironmentVariableSourceBuilder(proxy.Name, binding: "http")
+                        {
+                            Kind = EnvironmentVariableSourceBuilder.SourceKind.Port,
+                        },
+                    };
+                    project.EnvironmentVariables.Add(daprHttpPort);
 
                     // Set METRICS_PORT to a random port
                     var metricsPort = new EnvironmentVariableBuilder("METRICS_PORT")


### PR DESCRIPTION
Fixes: #575

Tye was missing code to set DAPR_HTTP_PORT when launching a project.
This variable is normally set by dapr when using `dapr run ...` to
launch a project. However Tye doesn't use `dapr run ...` so we need to
emulate this behavior.

We already had code to set up DAPR_GRPC_PORT which is used by the
`DaprClient` class. DAPR_HTTP_PORT is used by the actor runtime in
addition to behing available for arbitrary use (as reported in the
issue).