### PR TITLE
Add line break for better debug experience

### DIFF
--- a/src/Microsoft.Tye.Core/ProjectReader.cs
+++ b/src/Microsoft.Tye.Core/ProjectReader.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Tye
                     try
                     {
                         MSBuildLocator.RegisterInstance(instance);
-                        output?.WriteDebug("Registered .NET SDK.");
+                        output?.WriteDebugLine("Registered .NET SDK.");
                     }
                     finally
                     {


### PR DESCRIPTION
Without this you get `Registered .NET SDK.Loading project...` with no space or line break between the two statements when verbosity is set to `Debug`.