### PR TITLE
Resolve base docker images correctly for .NET 5.0+ projects

### DIFF
--- a/src/Microsoft.Tye.Core/DockerfileGenerator.cs
+++ b/src/Microsoft.Tye.Core/DockerfileGenerator.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Tye
                 }
                 else
                 {
-                    container.BaseImageName = project.IsAspNet ? "mcr.microsoft.com/dotnet/core/aspnet": "mcr.microsoft.com/dotnet/core/runtime";
+                    container.BaseImageName = project.IsAspNet ? "mcr.microsoft.com/dotnet/core/aspnet" : "mcr.microsoft.com/dotnet/core/runtime";
                 }
             }
 

--- a/src/Microsoft.Tye.Core/DockerfileGenerator.cs
+++ b/src/Microsoft.Tye.Core/DockerfileGenerator.cs
@@ -92,15 +92,6 @@ namespace Microsoft.Tye
                 throw new ArgumentNullException(nameof(container));
             }
 
-            if (string.IsNullOrEmpty(container.BaseImageName) && project.IsAspNet)
-            {
-                container.BaseImageName = "mcr.microsoft.com/dotnet/core/aspnet";
-            }
-            else if (string.IsNullOrEmpty(container.BaseImageName))
-            {
-                container.BaseImageName = "mcr.microsoft.com/dotnet/core/runtime";
-            }
-
             if (string.IsNullOrEmpty(container.BaseImageTag) && (project.TargetFrameworkName == "netcoreapp" || project.TargetFrameworkName == "net"))
             {
                 container.BaseImageTag = project.TargetFrameworkVersion;
@@ -111,8 +102,24 @@ namespace Microsoft.Tye
                 throw new CommandException($"Unsupported TFM {project.TargetFramework}.");
             }
 
-            container.BuildImageName ??= "mcr.microsoft.com/dotnet/core/sdk";
+            if (string.IsNullOrEmpty(container.BaseImageName))
+            {
+                if (TagIs50OrNewer(container.BaseImageTag))
+                {
+                    container.BaseImageName = project.IsAspNet ? "mcr.microsoft.com/dotnet/aspnet" : "mcr.microsoft.com/dotnet/runtime";
+                }
+                else
+                {
+                    container.BaseImageName = project.IsAspNet ? "mcr.microsoft.com/dotnet/core/aspnet": "mcr.microsoft.com/dotnet/core/runtime";
+                }
+            }
+
             container.BuildImageTag ??= project.TargetFrameworkVersion;
+
+            if (string.IsNullOrEmpty(container.BuildImageName))
+            {
+                container.BuildImageName = TagIs50OrNewer(container.BuildImageTag) ? "mcr.microsoft.com/dotnet/sdk" : "mcr.microsoft.com/dotnet/core/sdk";
+            }
 
             if (container.ImageName == null && application.Registry?.Hostname == null)
             {
@@ -141,6 +148,21 @@ namespace Microsoft.Tye
             }
 
             container.ImageTag ??= "latest";
+        }
+
+        public static bool TagIs50OrNewer(string tag)
+        {
+            if (string.Equals("latest", tag))
+            {
+                return true;
+            }
+
+            if (!Version.TryParse(tag, out var version))
+            {
+                throw new CommandException($"Could not determine version of docker image for tag: {tag}.");
+            }
+
+            return version.Major >= 5;
         }
     }
 }

--- a/src/Microsoft.Tye.Hosting/TransformProjectsIntoContainers.cs
+++ b/src/Microsoft.Tye.Hosting/TransformProjectsIntoContainers.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Tye.Hosting
             serviceDescription.RunInfo = dockerRunInfo;
         }
 
-        private string DetermineContainerImage(ProjectRunInfo project)
+        private static string DetermineContainerImage(ProjectRunInfo project)
         {
             var baseImageTag = !string.IsNullOrEmpty(project.ContainerBaseTag) ? project.ContainerBaseTag : project.TargetFrameworkVersion;
 
@@ -134,17 +134,7 @@ namespace Microsoft.Tye.Hosting
             }
             else
             {
-                Version? baseImageVersion = null;
-                try
-                {
-                    baseImageVersion = new Version(baseImageTag);
-                }
-                catch
-                {
-                    _logger.LogInformation($"Could not determine version of docker base image for tag: {baseImageTag}");
-                }
-
-                if (baseImageVersion?.Major >= 5)
+                if (DockerfileGenerator.TagIs50OrNewer(baseImageTag))
                 {
                     // .NET 5.0+ does not have the /core in its image name
                     baseImage = project.IsAspNet ? "mcr.microsoft.com/dotnet/aspnet" : "mcr.microsoft.com/dotnet/runtime";

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -148,7 +148,7 @@ services:
 
                 // Ensure correct image used
                 var dockerRunInfo = app.Services.Single().Value.Description.RunInfo as DockerRunInfo;
-                Assert.Equal(baseImage, dockerRunInfo.Image);
+                Assert.Equal(baseImage, dockerRunInfo?.Image);
 
                 // Ensure app runs
                 var testProjectUri = await GetServiceUrl(client, uri, "test-project");

--- a/test/E2ETest/testassets/projects/single-project-5.0/single-project.sln
+++ b/test/E2ETest/testassets/projects/single-project-5.0/single-project.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test-project", "test-project\test-project.csproj", "{7D3606B2-7B8E-4ABB-BE0A-E0B18285D8F5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7D3606B2-7B8E-4ABB-BE0A-E0B18285D8F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D3606B2-7B8E-4ABB-BE0A-E0B18285D8F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D3606B2-7B8E-4ABB-BE0A-E0B18285D8F5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7D3606B2-7B8E-4ABB-BE0A-E0B18285D8F5}.Debug|x64.Build.0 = Debug|Any CPU
+		{7D3606B2-7B8E-4ABB-BE0A-E0B18285D8F5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7D3606B2-7B8E-4ABB-BE0A-E0B18285D8F5}.Debug|x86.Build.0 = Debug|Any CPU
+		{7D3606B2-7B8E-4ABB-BE0A-E0B18285D8F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D3606B2-7B8E-4ABB-BE0A-E0B18285D8F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D3606B2-7B8E-4ABB-BE0A-E0B18285D8F5}.Release|x64.ActiveCfg = Release|Any CPU
+		{7D3606B2-7B8E-4ABB-BE0A-E0B18285D8F5}.Release|x64.Build.0 = Release|Any CPU
+		{7D3606B2-7B8E-4ABB-BE0A-E0B18285D8F5}.Release|x86.ActiveCfg = Release|Any CPU
+		{7D3606B2-7B8E-4ABB-BE0A-E0B18285D8F5}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/test/E2ETest/testassets/projects/single-project-5.0/test-project/Program.cs
+++ b/test/E2ETest/testassets/projects/single-project-5.0/test-project/Program.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace test_project
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/test/E2ETest/testassets/projects/single-project-5.0/test-project/Startup.cs
+++ b/test/E2ETest/testassets/projects/single-project-5.0/test-project/Startup.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace test_project
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapGet("/", async context =>
+                {
+                    await context.Response.WriteAsync("Hello World!");
+                });
+            });
+        }
+    }
+}

--- a/test/E2ETest/testassets/projects/single-project-5.0/test-project/appsettings.Development.json
+++ b/test/E2ETest/testassets/projects/single-project-5.0/test-project/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/test/E2ETest/testassets/projects/single-project-5.0/test-project/appsettings.json
+++ b/test/E2ETest/testassets/projects/single-project-5.0/test-project/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/test/E2ETest/testassets/projects/single-project-5.0/test-project/test-project.csproj
+++ b/test/E2ETest/testassets/projects/single-project-5.0/test-project/test-project.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <RootNamespace>test_project</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/test/E2ETest/testassets/projects/single-project-5.0/tye.yaml
+++ b/test/E2ETest/testassets/projects/single-project-5.0/tye.yaml
@@ -1,0 +1,6 @@
+# tye application configuration file
+# read all about it at https://github.com/dotnet/tye
+name: single-project
+services:
+- name: test-project
+  project: test-project/test-project.csproj


### PR DESCRIPTION
Fixes https://github.com/dotnet/tye/issues/683. Note that the naming scheme is dependent on the TFM of the project: https://hub.docker.com/_/microsoft-dotnet-core