### PR TITLE
Fix resolution of TFM overrides for multi-tfm projects

### DIFF
--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -84,8 +84,8 @@ namespace Microsoft.Tye
                 var projectMetadata = new Dictionary<string, string>();
 
                 var msbuildEvaluationResult = await EvaluateProjectsAsync(
-                    projects: projectServices, 
-                    configRoot: config.Source.DirectoryName!, 
+                    projects: projectServices,
+                    configRoot: config.Source.DirectoryName!,
                     output: output);
                 var msbuildEvaluationOutput = msbuildEvaluationResult
                     .StandardOutput

--- a/src/Microsoft.Tye.Core/StandardOptions.cs
+++ b/src/Microsoft.Tye.Core/StandardOptions.cs
@@ -49,9 +49,9 @@ namespace Microsoft.Tye
         public static Option Framework =>
                     new Option(new string[] { "-f", "--framework" })
                     {
-                        Description = "The target framework override to use for all cross-targeting projects with multiple TFMs. " +
+                        Description = "The target framework hint to use for all cross-targeting projects with multiple TFMs. " +
                             "This value must be a valid target framework for each individual cross-targeting project. " +
-                            "Non-crosstargeting projects will ignore this value. ",
+                            "Non-crosstargeting projects will ignore this hint and the value TFM configured in tye.yaml will override this hint. ",
                         Argument = new Argument<string>("framework")
                         {
                             Arity = ArgumentArity.ExactlyOne

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -121,11 +121,11 @@ namespace Microsoft.Tye.Hosting
                 var projectPath = Path.Combine(directory.DirectoryPath, Path.GetRandomFileName() + ".proj");
 
                 var sb = new StringBuilder();
-                sb.AppendLine(@"<Project DefaultTargets=""Build"">
-    <ItemGroup>");
+                sb.AppendLine(@"<Project DefaultTargets=""Build"">");
 
                 foreach (var group in projectGroups)
                 {
+                    sb.AppendLine(@"    <ItemGroup>");
                     foreach (var p in group.Value.Services)
                     {
                         sb.AppendLine($"        <{group.Value.GroupName} Include=\"{p.Status.ProjectFilePath}\" />");

--- a/src/tye/ApplicationBuilderExtensions.cs
+++ b/src/tye/ApplicationBuilderExtensions.cs
@@ -121,21 +121,6 @@ namespace Microsoft.Tye
                 }
                 else if (service is DotnetProjectServiceBuilder project)
                 {
-                    if (project.TargetFrameworks.Length > 1)
-                    {
-                        if (project.BuildProperties.TryGetValue("TargetFramework", out var targetFramework))
-                        {
-                            if (!project.TargetFrameworks.Contains(targetFramework))
-                            {
-                                throw new InvalidOperationException($"Unable to run {project.Name}. The specified TargetFramework is not one of the existing TargetFrameworks in the project.");
-                            }
-                        }
-                        else
-                        {
-                            throw new InvalidOperationException($"Unable to run {project.Name}. Your project targets multiple frameworks. Specify which framework to run using '--framework'.");
-                        }
-                    }
-
                     if (project.RunCommand == null)
                     {
                         throw new InvalidOperationException($"Unable to run {project.Name}. The project does not have a run command");

--- a/src/tye/ProjectEvaluation.targets
+++ b/src/tye/ProjectEvaluation.targets
@@ -1,48 +1,50 @@
 ﻿<Project>
+  <PropertyGroup>
+    <!-- Single TFM projects -->
+    <MicrosoftTye_GetProjectMetadata_DependsOn>Restore;ResolveReferences;ResolvePackageDependenciesDesignTime;PrepareResources;PrepareResources;GetAssemblyAttributes</MicrosoftTye_GetProjectMetadata_DependsOn>
+    <!-- Multi TFM projects -->
+    <MicrosoftTye_GetProjectMetadata_DependsOn Condition="'$(IsCrossTargetingBuild)' == 'true'">Restore</MicrosoftTye_GetProjectMetadata_DependsOn>
+  </PropertyGroup>
+
+  <Target Name="MicrosoftTye_GetProjectMetadata" DependsOnTargets="$(MicrosoftTye_GetProjectMetadata_DependsOn)" >
     <PropertyGroup>
-       <!-- Single TFM projects -->
-      <MicrosoftTye_GetProjectMetadata_DependsOn>Restore;ResolveReferences;ResolvePackageDependenciesDesignTime;PrepareResources;PrepareResources;GetAssemblyAttributes</MicrosoftTye_GetProjectMetadata_DependsOn>
-      <!-- Multi TFM projects -->
-        <MicrosoftTye_GetProjectMetadata_DependsOn Condition="'$(IsCrossTargetingBuild)' == 'true'">Restore</MicrosoftTye_GetProjectMetadata_DependsOn>
+      <_MicrosoftTye_MetadataFile>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)MicrosoftTye.ProjectMetadata.txt'))</_MicrosoftTye_MetadataFile>
+      <_MicrosoftTye_ProjectFrameworkReference>@(FrameworkReference, '%3B')</_MicrosoftTye_ProjectFrameworkReference>
+      <_MicrosoftTye_ProjectFrameworks>$(TargetFrameworks.Replace(';', '%3B'))</_MicrosoftTye_ProjectFrameworks>
     </PropertyGroup>
 
-    <Target Name="MicrosoftTye_GetProjectMetadata" DependsOnTargets="$(MicrosoftTye_GetProjectMetadata_DependsOn)" >
-        <PropertyGroup>
-            <_MicrosoftTye_MetadataFile>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)MicrosoftTye.ProjectMetadata.txt'))</_MicrosoftTye_MetadataFile>
-          <_MicrosoftTye_ProjectFrameworkReference>@(FrameworkReference, '%3B')</_MicrosoftTye_ProjectFrameworkReference>
-          <_MicrosoftTye_ProjectFrameworks>$(TargetFrameworks.Replace(';', '%3B'))</_MicrosoftTye_ProjectFrameworks>
-        </PropertyGroup>
+    <ItemGroup>
+      <_MicrosoftTye_ProjectMetadata Include="AssemblyInformationalVersion: $(AssemblyInformationalVersion)" />
+      <_MicrosoftTye_ProjectMetadata Include="InformationalVersion: $(InformationalVersion)" />
+      <_MicrosoftTye_ProjectMetadata Include="Version: $(Version)" />
+      <_MicrosoftTye_ProjectMetadata Include="TargetFrameworks: $(_MicrosoftTye_ProjectFrameworks)" />
+      <_MicrosoftTye_ProjectMetadata Include="RunCommand: $(RunCommand)" />
+      <_MicrosoftTye_ProjectMetadata Include="RunArguments: $(RunArguments)" />
+      <_MicrosoftTye_ProjectMetadata Include="TargetPath: $(TargetPath)" />
+      <_MicrosoftTye_ProjectMetadata Include="PublishDir: $(PublishDir)" />
+      <_MicrosoftTye_ProjectMetadata Include="AssemblyName: $(AssemblyName)" />
+      <_MicrosoftTye_ProjectMetadata Include="IntermediateOutputPath: $(IntermediateOutputPath)" />
+      <_MicrosoftTye_ProjectMetadata Include="TargetFramework: $(TargetFramework)" />
+      <_MicrosoftTye_ProjectMetadata Include="_ShortFrameworkIdentifier: $(_ShortFrameworkIdentifier)" />
+      <_MicrosoftTye_ProjectMetadata Include="_ShortFrameworkVersion: $(_ShortFrameworkVersion)" />
+      <_MicrosoftTye_ProjectMetadata Include="_TargetFrameworkVersionWithoutV: $(_TargetFrameworkVersionWithoutV)" />
+      <_MicrosoftTye_ProjectMetadata Include="FrameworkReference: $(_MicrosoftTye_ProjectFrameworkReference)" />
+      <_MicrosoftTye_ProjectMetadata Include="ContainerBaseImage: $(ContainerBaseImage)" />
+      <_MicrosoftTye_ProjectMetadata Include="ContainerBaseTag: $(ContainerBaseTag)" />
+      <_MicrosoftTye_ProjectMetadata Include="MicrosoftNETPlatformLibrary: $(MicrosoftNETPlatformLibrary)" />
+      <_MicrosoftTye_ProjectMetadata Include="_AspNetCoreAppSharedFxIsEnabled: $(_AspNetCoreAppSharedFxIsEnabled)" />
+      <_MicrosoftTye_ProjectMetadata Include="UsingMicrosoftNETSdkWeb: $(UsingMicrosoftNETSdkWeb)" />
+    </ItemGroup>
 
-        <ItemGroup>
-            <_MicrosoftTye_ProjectMetadata Include="AssemblyInformationalVersion: $(AssemblyInformationalVersion)" />
-            <_MicrosoftTye_ProjectMetadata Include="InformationalVersion: $(InformationalVersion)" />
-            <_MicrosoftTye_ProjectMetadata Include="Version: $(Version)" />
-            <_MicrosoftTye_ProjectMetadata Include="TargetFrameworks: $(_MicrosoftTye_ProjectFrameworks)" />
-            <_MicrosoftTye_ProjectMetadata Include="RunCommand: $(RunCommand)" />
-            <_MicrosoftTye_ProjectMetadata Include="RunArguments: $(RunArguments)" />
-            <_MicrosoftTye_ProjectMetadata Include="TargetPath: $(TargetPath)" />
-            <_MicrosoftTye_ProjectMetadata Include="PublishDir: $(PublishDir)" />
-            <_MicrosoftTye_ProjectMetadata Include="AssemblyName: $(AssemblyName)" />
-            <_MicrosoftTye_ProjectMetadata Include="IntermediateOutputPath: $(IntermediateOutputPath)" />
-            <_MicrosoftTye_ProjectMetadata Include="TargetFramework: $(TargetFramework)" />
-            <_MicrosoftTye_ProjectMetadata Include="_ShortFrameworkIdentifier: $(_ShortFrameworkIdentifier)" />
-            <_MicrosoftTye_ProjectMetadata Include="_ShortFrameworkVersion: $(_ShortFrameworkVersion)" />
-            <_MicrosoftTye_ProjectMetadata Include="_TargetFrameworkVersionWithoutV: $(_TargetFrameworkVersionWithoutV)" />
-            <_MicrosoftTye_ProjectMetadata Include="FrameworkReference: $(_MicrosoftTye_ProjectFrameworkReference)" />
-            <_MicrosoftTye_ProjectMetadata Include="ContainerBaseImage: $(ContainerBaseImage)" />
-            <_MicrosoftTye_ProjectMetadata Include="ContainerBaseTag: $(ContainerBaseTag)" />
-            <_MicrosoftTye_ProjectMetadata Include="MicrosoftNETPlatformLibrary: $(MicrosoftNETPlatformLibrary)" />
-            <_MicrosoftTye_ProjectMetadata Include="_AspNetCoreAppSharedFxIsEnabled: $(_AspNetCoreAppSharedFxIsEnabled)" />
-            <_MicrosoftTye_ProjectMetadata Include="UsingMicrosoftNETSdkWeb: $(UsingMicrosoftNETSdkWeb)" />
-        </ItemGroup>
+    <WriteLinesToFile
+      File="$(_MicrosoftTye_MetadataFile)"
+      Lines="@(_MicrosoftTye_ProjectMetadata)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true"
+      Condition="'$(IsCrossTargetingBuild)' != 'true'"/>
 
-        <WriteLinesToFile
-            File="$(_MicrosoftTye_MetadataFile)"
-            Lines="@(_MicrosoftTye_ProjectMetadata)"
-            Overwrite="true"
-            WriteOnlyWhenDifferent="true"/>
+    <Message Text="Microsoft.Tye cross-targeting project: $(MicrosoftTye_ProjectName)" Importance="High" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
+    <Message Text="Microsoft.Tye metadata: $(MicrosoftTye_ProjectName): $(_MicrosoftTye_MetadataFile)" Importance="High" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
 
-        <Message Text="Microsoft.Tye metadata: $(MicrosoftTye_ProjectName): $(_MicrosoftTye_MetadataFile)" Importance="High"/>
-
-    </Target>
+  </Target>
 </Project>

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -1005,13 +1005,13 @@ services:
 
         [ConditionalFact]
         [SkipIfDockerNotRunning]
-        public async Task RunCliArgOverrideYamlMultipleTargetFrameworksTest()
+        public async Task RunCliArgDoesNotOverrideYamlMultipleTargetFrameworksTest()
         {
             using var projectDirectory = CopyTestProjectDirectory("multi-targetframeworks");
 
-            var projectFile = new FileInfo(Path.Combine(projectDirectory.DirectoryPath, "tye-with-netcoreapp21.yaml"));
+            var projectFile = new FileInfo(Path.Combine(projectDirectory.DirectoryPath, "tye-with-netcoreapp31.yaml"));
             var outputContext = new OutputContext(_sink, Verbosity.Debug);
-            var application = await ApplicationFactory.CreateAsync(outputContext, projectFile, "netcoreapp3.1");
+            var application = await ApplicationFactory.CreateAsync(outputContext, projectFile, "netcoreapp2.1");
 
             var handler = new HttpClientHandler
             {


### PR DESCRIPTION
The main issue I hit during verification was that the override logic we had didn't work as intended.

Imagine the following scenario: 
1. The project is cross-targeting netcoreapp3.1 and net5.0
2. There is configuration in tye.yaml that specifies the TargetFramework to be net5.0
3. There is a command line argument --framework net3.1

Since we want to optimize evaluation speed, we opted for batching. Ideally, we would be able to send all the information, the TFM from tye.yaml and the hint from the command line, to MSBuild and have it sort out which TFM to restore/build for during project evaluation. 

However, I spent some time looking into the SDK and it looks like there's no chance for us to customize the logic. The SDK determines whether it's a cross-targeting build immediately when it's imported and there's no customization available for us to hook into before that's done. As such I'm changing the approach here to evaluate projects in two batches. The first evaluate all projects and determines which are cross-targeting. The second batch evaluates all cross-targeting projects using the hint from the CLI if provided. 

As a fallout from that, I think the build properties in the tye.yaml should take precedence over cli args. I feel that the cli args should only be relevant if a cross-targeting project is lacking a TFM. I could be convinced otherwise here though.

As for testing, I've been testing with some of the scenarios in our tutorials with modifications for multi-tfm projects. I'm also looking to add a test for the scenario that wasn't covered when I found the bug.