### PR TITLE
Update ingress apiVersion now that it's not supposed to be beta anymore

### DIFF
--- a/samples/voting/ingress.yml
+++ b/samples/voting/ingress.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-basic

--- a/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
+++ b/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Tye
             var root = new YamlMappingNode();
 
             root.Add("kind", "Ingress");
-            root.Add("apiVersion", "extensions/v1beta1");
+            root.Add("apiVersion", "networking.k8s.io/v1");
 
             var metadata = new YamlMappingNode();
             root.Add("metadata", metadata);

--- a/src/Microsoft.Tye.Core/ValidateIngressStep.cs
+++ b/src/Microsoft.Tye.Core/ValidateIngressStep.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Tye
                 // after creating the controller will fail if the webhook isn't ready.
                 //
                 // Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": 
-                // Post https://ingress-nginx-controller-admission.ingress-nginx.svc:443/extensions/v1beta1/ingresses?timeout=30s:
+                // Post https://ingress-nginx-controller-admission.ingress-nginx.svc:443/networking.k8s.io/v1/ingresses?timeout=30s:
                 // dial tcp 10.0.31.130:443: connect: connection refused
                 //
                 // Unfortunately this is the likely case for us.

--- a/test/E2ETest/testassets/generate/apps-with-ingress.yaml
+++ b/test/E2ETest/testassets/generate/apps-with-ingress.yaml
@@ -125,7 +125,7 @@ spec:
 ...
 ---
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: ingress
   annotations:


### PR DESCRIPTION
fixes #737 

This PR is just a "find and replace" from `extensions/v1beta1` to `networking.k8s.io/v1` for the ingress part
@jongio can you confirm if I missed something ? It looks too simple to be just this in the PR and you might have seen something else ^^

I would also love double check if that URL here is to be updated too it look like URI from inside the cluster to reach the ingress(es)
```
                // We need to then wait for the webhooks that are created by ingress-nginx to start. Deploying an ingress immediately
                // after creating the controller will fail if the webhook isn't ready.
                //
                // Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": 
                // Post https://ingress-nginx-controller-admission.ingress-nginx.svc:443/networking.k8s.io/v1/ingresses?timeout=30s:
                // dial tcp 10.0.31.130:443: connect: connection refused
                //
                // Unfortunately this is the likely case for us.
```