### PR TITLE
Map "binding.ContainerPort" instead of "binding.Port" to "manifest containerPort"

### DIFF
--- a/src/Microsoft.Tye.Core/CombineStep.cs
+++ b/src/Microsoft.Tye.Core/CombineStep.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Tye
 
                 if (binding.Protocol == "http")
                 {
-                    var port = binding.Port ?? 80;
+                    var port = binding.ContainerPort ?? binding.Port ?? 80;
                     var urls = $"http://*{(port == 80 ? "" : (":" + port.ToString()))}";
                     project.EnvironmentVariables.Add(new EnvironmentVariableBuilder("ASPNETCORE_URLS") { Value = urls, });
                     project.EnvironmentVariables.Add(new EnvironmentVariableBuilder("PORT") { Value = port.ToString(CultureInfo.InvariantCulture), });

--- a/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
+++ b/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
@@ -183,11 +183,7 @@ namespace Microsoft.Tye
                     port.Add("name", binding.Name ?? binding.Protocol ?? "http");
                     port.Add("protocol", "TCP"); // we use assume TCP. YOLO
                     port.Add("port", binding.Port.Value.ToString());
-
-                    // this ?
                     port.Add("targetPort", (binding.ContainerPort ?? binding.Port.Value).ToString());
-                    // or this ?
-                    // port.Add("targetPort", (binding.ContainerPort ?? 80).ToString());
                 }
             }
 
@@ -378,11 +374,7 @@ namespace Microsoft.Tye
                         {
                             var containerPort = new YamlMappingNode();
                             ports.Add(containerPort);
-
-                            // this ?
                             containerPort.Add("containerPort", (binding.ContainerPort ?? binding.Port.Value).ToString());
-                            // or this ?
-                            //containerPort.Add("containerPort", (binding.ContainerPort ?? 80).ToString());
                         }
 
                     }

--- a/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
+++ b/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
@@ -183,7 +183,11 @@ namespace Microsoft.Tye
                     port.Add("name", binding.Name ?? binding.Protocol ?? "http");
                     port.Add("protocol", "TCP"); // we use assume TCP. YOLO
                     port.Add("port", binding.Port.Value.ToString());
-                    port.Add("targetPort", binding.Port.Value.ToString());
+
+                    // this ?
+                    port.Add("targetPort", (binding.ContainerPort ?? binding.Port.Value).ToString());
+                    // or this ?
+                    // port.Add("targetPort", (binding.ContainerPort ?? 80).ToString());
                 }
             }
 
@@ -374,8 +378,13 @@ namespace Microsoft.Tye
                         {
                             var containerPort = new YamlMappingNode();
                             ports.Add(containerPort);
-                            containerPort.Add("containerPort", binding.Port.Value.ToString());
+
+                            // this ?
+                            containerPort.Add("containerPort", (binding.ContainerPort ?? binding.Port.Value).ToString());
+                            // or this ?
+                            //containerPort.Add("containerPort", (binding.ContainerPort ?? 80).ToString());
                         }
+
                     }
                 }
 

--- a/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
+++ b/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
@@ -376,7 +376,6 @@ namespace Microsoft.Tye
                             ports.Add(containerPort);
                             containerPort.Add("containerPort", (binding.ContainerPort ?? binding.Port.Value).ToString());
                         }
-
                     }
                 }
 


### PR DESCRIPTION
fixes #725

It seems that the manifest code was mapping `binding.Port" to the field "containerPort" inthe  `KubernetesManifestGenerator`
As I have, for now, a limited understanding on that, There might be other underlying reason that I'm missing here

Adding back context from the Issue here for review:

From @jongio
https://github.com/dotnet/tye/issues/725#issuecomment-719975984
> Here's what I recommend:
> 
> If tye.yaml has containerPort, then use it for both containerPort in the deployment and targetPort in the service
> If tye.yaml doesn't have containerPort, then use 80 for http and 443 for https for both containerPort and targetPort.
> 
> I personally do not see a scenario where containerPort or targetPort should be equal to port
> 
> @jkotalik to confirm the logic above, but @tebeco if you want to take a stab at updating to that, you are more than welcome to mod your PR.

This PR only covers `HTTP` scheme and not `HTTPS` due to the current absence of support yet for `HTTPS` :
```cs
                        if (binding.Protocol == "https")
                        {
                            // We skip https for now in deployment, because the E2E requires certificates
                            // and we haven't done those features yet.
                            continue;
                        }
```

What troubles me ?
`tye.yaml` seem to have the notion of `port` binding that seems to be used for local run when doing `tye run`
What happens when there's a `port: 1111` specified but no `containerPort` ? Should it default to `80` ? or should it use the existing/defined `port` ?
eg:
```yaml
name: foobar
services:
- name: thewebapione
  project: src/TheWebapiOne/TheWebapiOne.csproj
  bindings:
    - port: 1111
      protocol: http
```

This would feel like a dup to have to do:
```yaml
name: foobar
services:
- name: thewebapione
  project: src/TheWebapiOne/TheWebapiOne.csproj
  bindings:
    - port: 1111
      protocol: http
      containerPort: 1111
```