### PR TITLE
Adds preservePath for ingress

### DIFF
--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -465,6 +465,7 @@ namespace Microsoft.Tye
                         {
                             Host = configRule.Host,
                             Path = configRule.Path,
+                            PreservePath = configRule.PreservePath,
                             Service = configRule.Service!, // validated elsewhere
                         };
                         ingress.Rules.Add(rule);

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigIngressRule.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigIngressRule.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Tye.ConfigModel
     {
         public string? Path { get; set; }
         public string? Host { get; set; }
+        public bool PreservePath { get; set; }
 
         [Required]
         public string? Service { get; set; }

--- a/src/Microsoft.Tye.Core/IngressRuleBuilder.cs
+++ b/src/Microsoft.Tye.Core/IngressRuleBuilder.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Tye
     {
         public string? Path { get; set; }
         public string? Host { get; set; }
+        public bool PreservePath { get; set; }
+
         public string Service { get; set; } = default!;
     }
 }

--- a/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
+++ b/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Tye
                         //
                         // Therefore our rewrite-target is set to $2 - we want to make sure we have
                         // two capture groups.
-                        if (string.IsNullOrEmpty(ingressRule.Path) || ingressRule.Path == "/")
+                        if (string.IsNullOrEmpty(ingressRule.Path) || ingressRule.Path == "/" || ingressRule.PreservePath)
                         {
                             path.Add("path", "/()(.*)"); // () is an empty capture group.
                         }

--- a/src/Microsoft.Tye.Core/Serialization/ConfigIngressParser.cs
+++ b/src/Microsoft.Tye.Core/Serialization/ConfigIngressParser.cs
@@ -98,6 +98,13 @@ namespace Tye.Serialization
                     case "path":
                         rule.Path = YamlParser.GetScalarValue(key, child.Value);
                         break;
+                    case "preservePath":
+                        if (!bool.TryParse(YamlParser.GetScalarValue(key, child.Value), out var preservePath))
+                        {
+                            throw new TyeYamlException(child.Value.Start, CoreStrings.FormatMustBeABoolean(key));
+                        }
+                        rule.PreservePath = preservePath;
+                        break;
                     case "service":
                         rule.Service = YamlParser.GetScalarValue(key, child.Value).ToLowerInvariant();
                         break;

--- a/src/Microsoft.Tye.Hosting/DockerRunner.cs
+++ b/src/Microsoft.Tye.Hosting/DockerRunner.cs
@@ -53,7 +53,9 @@ namespace Microsoft.Tye.Hosting
             var proxies = new List<Service>();
             foreach (var service in application.Services.Values)
             {
-                if (service.Description.RunInfo is DockerRunInfo || service.Description.Bindings.Count == 0)
+                if (service.Description.RunInfo is DockerRunInfo ||
+                    service.Description.RunInfo is IngressRunInfo ||
+                    service.Description.Bindings.Count == 0)
                 {
                     continue;
                 }

--- a/src/Microsoft.Tye.Hosting/HttpProxyService.cs
+++ b/src/Microsoft.Tye.Hosting/HttpProxyService.cs
@@ -151,10 +151,9 @@ namespace Microsoft.Tye.Hosting
                                 await context.Response.WriteAsync("Bad gateway");
                                 return;
                             }
-
                             var uri = new UriBuilder(uris[next].Uri)
                             {
-                                Path = (string)context.Request.RouteValues["path"]!,
+                                Path = rule.PreservePath ? $"{context.Request.Path}{context.Request.RouteValues["path"]}" : (string)context.Request.RouteValues["path"] ?? "/",
                                 Query = context.Request.QueryString.Value
                             };
 

--- a/src/Microsoft.Tye.Hosting/Model/IngressRule.cs
+++ b/src/Microsoft.Tye.Hosting/Model/IngressRule.cs
@@ -11,15 +11,17 @@ namespace Microsoft.Tye.Hosting.Model
 {
     public class IngressRule
     {
-        public IngressRule(string? host, string? path, string service)
+        public IngressRule(string? host, string? path, string service, bool preservePath)
         {
             Host = host;
             Path = path;
+            PreservePath = preservePath;
             Service = service;
         }
 
         public string? Host { get; }
         public string? Path { get; }
+        public bool PreservePath { get; }
         public string Service { get; }
     }
 }

--- a/src/schema/tye-schema.json
+++ b/src/schema/tye-schema.json
@@ -447,6 +447,10 @@
                 "protocol": {
                     "description": "The protocol used by the binding",
                     "type": "string"
+                },
+                "preservePath": {
+                    "description": "Whether to keep the path that was originally present or not.",
+                    "type": "boolean"
                 }
             }
         },

--- a/src/tye/ApplicationBuilderExtensions.cs
+++ b/src/tye/ApplicationBuilderExtensions.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Tye
 
                 foreach (var rule in ingress.Rules)
                 {
-                    rules.Add(new IngressRule(rule.Host, rule.Path, rule.Service!));
+                    rules.Add(new IngressRule(rule.Host, rule.Path, rule.Service!, rule.PreservePath));
                 }
 
                 var runInfo = new IngressRunInfo(rules);


### PR DESCRIPTION
Porting from https://github.com/dotnet/tye/pull/463. This will keep the path if a path is given for a particular redirect rule.

Fixes https://github.com/dotnet/tye/issues/729