### PR TITLE
#766 fix missing msbuild error code output

### DIFF
--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -87,6 +87,10 @@ namespace Microsoft.Tye
                     projects: projectServices,
                     configRoot: config.Source.DirectoryName!,
                     output: output);
+                if (msbuildEvaluationResult.ExitCode != 0)
+                {
+                    throw new CommandException($"Unable to parse output.\r\n{msbuildEvaluationResult.StandardOutput}.\r\n Try buildMSBuild error.");
+                }
                 var msbuildEvaluationOutput = msbuildEvaluationResult
                     .StandardOutput
                     .Split(Environment.NewLine);


### PR DESCRIPTION
MSBuild error wasn't written to console for some reason. Restore task fails and no section is available yet for parsing. Is it acceptable solution?
  