### PR TITLE
Fix dapr recipe documentation and update sample to use latest .Net Dapr sdk

### DIFF
--- a/docs/recipes/dapr.md
+++ b/docs/recipes/dapr.md
@@ -12,9 +12,14 @@ Getting started documentation for Dapr can be found [here](https://docs.dapr.io/
 
 ## Sample Code
 
-The sample code for document can be found [here](https://github.com/dotnet/tye/tree/master/samples/dapr).
+There are two sample projects for the Dapr recipe [here](https://github.com/dotnet/tye/tree/master/samples/dapr).
 
-This application has three services:
+They demonstrate
+
+- Pub/Sub (The sample code associated with the instructions below.)
+- Service Invocation
+
+The pub-sub sample application has three services:
 
 - A frontend application (`store`)
 - A products backend service (`products`)
@@ -22,15 +27,15 @@ This application has three services:
 
 These services use a variety of Dapr's features:
 
-- State Storate (`store`)
+- State Storage (`store`)
 - Invoke (`store`, `products`)
 - Pub/Sub (`store`, `orders`)
 
-You can find the Dapr component files [here](https://github.com/dotnet/tye/tree/master/samples/dapr/components).
+You can find the Dapr component files for the sample project [here](https://github.com/dotnet/tye/tree/master/samples/dapr/pub-sub/components).
 
 ## Running the sample locally
 
-To run this sample, simply go to the `samples/dapr` directory and run the following command:
+To run this sample, simply go to the `samples/dapr/pub-sub` directory and run the following command:
 
 ```sh
 tye run
@@ -65,7 +70,7 @@ Each application would need to be given a unique port to listen on, and launched
 Tye has built-in support that can make this more productive by:
 
 - Launching everything at once
-- Automatically manging ports
+- Automatically managing ports
 
 Tye's Dapr integration is activated in `tye.yaml` (seen below for this sample):
 

--- a/samples/dapr/service-invocation/SentenceApp/SentenceApp.csproj
+++ b/samples/dapr/service-invocation/SentenceApp/SentenceApp.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="0.11.0-preview02" />
-    <PackageReference Include="Dapr.Client" Version="0.11.0-preview02" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.0.0-rc02" />
+    <PackageReference Include="Dapr.Client" Version="1.0.0-rc02" />
     <PackageReference Include="Microsoft.Tye.Extensions.Configuration" Version="0.5.0-alpha.20555.1" />
   </ItemGroup>
 

--- a/samples/dapr/service-invocation/SentenceApp/Services/LowercaseServiceClient.cs
+++ b/samples/dapr/service-invocation/SentenceApp/Services/LowercaseServiceClient.cs
@@ -1,9 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Dapr.Client;
-using Dapr.Client.Http;
 using Shared;
 
 namespace SentenceApp.Services
@@ -28,15 +26,11 @@ namespace SentenceApp.Services
         public async Task<ConvertedResult> Convert(string sentence)
         {
             // Using Dapr sidecar and service invocation building block
-            return await _daprClient.InvokeMethodAsync<object, ConvertedResult>("lowercaseservice", "lowercase", new object(), new HTTPExtension()
-            {
-                QueryString = new Dictionary<string, string>()
-                {
-                    {"sentence", sentence}
-                },
-                Verb = HTTPVerb.Get
-            });
+            return await _daprClient.InvokeMethodAsync<object, ConvertedResult>("lowercaseservice", "lowercase", new object(), 
+                HttpInvocationOptions.UsingGet()
+                    .WithQueryParam("sentence", sentence));
 
+            // If you're using Tye alone (without dapr)
             //var responseMessage = await _client.GetAsync($"/lowercase?sentence={sentence}");
             //var stream = await responseMessage.Content.ReadAsStreamAsync();
             //return await JsonSerializer.DeserializeAsync<ConvertedResult>(stream, _options);

--- a/samples/dapr/service-invocation/SentenceApp/Services/TitlecaseServiceClient.cs
+++ b/samples/dapr/service-invocation/SentenceApp/Services/TitlecaseServiceClient.cs
@@ -1,9 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Dapr.Client;
-using Dapr.Client.Http;
 using Shared;
 
 namespace SentenceApp.Services
@@ -28,16 +26,11 @@ namespace SentenceApp.Services
         public async Task<ConvertedResult> Convert(string sentence)
         {
             // Using Dapr sidecar and service invocation building block
-            return await _daprClient.InvokeMethodAsync<object, ConvertedResult>("titlecaseservice", "titlecase", new object(), new HTTPExtension()
-            {
-                QueryString = new Dictionary<string, string>()
-                {
-                    {"sentence", sentence}
-                },
-                Verb = HTTPVerb.Get
-            });
+            return await _daprClient.InvokeMethodAsync<object, ConvertedResult>("titlecaseservice", "titlecase", new object(), 
+                HttpInvocationOptions.UsingGet()
+                    .WithQueryParam("sentence", sentence));
 
-            // If you're using Tye alone
+            // If you're using Tye alone (without dapr)
             //var responseMessage = await _client.GetAsync($"/titlecase?sentence={sentence}");
             //var stream = await responseMessage.Content.ReadAsStreamAsync();
             //return await JsonSerializer.DeserializeAsync<ConvertedResult>(stream, _options);

--- a/samples/dapr/service-invocation/SentenceApp/Services/UppercaseServiceClient.cs
+++ b/samples/dapr/service-invocation/SentenceApp/Services/UppercaseServiceClient.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Dapr.Client;
-using Dapr.Client.Http;
 using Shared;
 
 namespace SentenceApp.Services
@@ -30,16 +26,11 @@ namespace SentenceApp.Services
         public async Task<ConvertedResult> Convert(string sentence)
         {
             // Using Dapr sidecar and service invocation building block
-            return await _daprClient.InvokeMethodAsync<object, ConvertedResult>("uppercaseservice", "uppercase", new object(), new HTTPExtension()
-            {
-                QueryString = new Dictionary<string, string>()
-                {
-                    {"sentence", sentence}
-                },
-                Verb = HTTPVerb.Get
-            });
+            return await _daprClient.InvokeMethodAsync<object, ConvertedResult>("uppercaseservice", "uppercase", new object(),
+                HttpInvocationOptions.UsingGet()
+                    .WithQueryParam("sentence", sentence));
 
-            // If you're using Tye alone
+            // If you're using Tye alone (without dapr)
             //var responseMessage = await _client.GetAsync($"/uppercase?sentence={sentence}");
             //var stream = await responseMessage.Content.ReadAsStreamAsync();
             //return await JsonSerializer.DeserializeAsync<ConvertedResult>(stream, _options);


### PR DESCRIPTION
This PR fixes some broken links in the Dapr recipe document and updates the service invocation sample to use the latest Dapr .NET SDK.