### PR TITLE
adapt breaking changes of dapr 1.0.0.rc.1

### DIFF
--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -248,8 +248,8 @@ namespace Microsoft.Tye.Extensions.Dapr
                     }
 
                     deployment.Annotations.Add("dapr.io/enabled", "true");
-                    deployment.Annotations.Add("dapr.io/id", project.Name);
-                    deployment.Annotations.Add("dapr.io/port", (httpBinding.Port ?? 80).ToString(CultureInfo.InvariantCulture));
+                    deployment.Annotations.Add("dapr.io/app-id", project.Name);
+                    deployment.Annotations.Add("dapr.io/app-port", (httpBinding.Port ?? 80).ToString(CultureInfo.InvariantCulture));
 
                     if (config.Data.TryGetValue("config", out var obj) && obj?.ToString() is string daprConfig)
                     {

--- a/test/E2ETest/testassets/generate/dapr.yaml
+++ b/test/E2ETest/testassets/generate/dapr.yaml
@@ -4,8 +4,8 @@ metadata:
   name: dapr-test-project
   annotations:
     dapr.io/enabled: 'true'
-    dapr.io/id: 'dapr-test-project'
-    dapr.io/port: '80'
+    dapr.io/app-id: 'dapr-test-project'
+    dapr.io/app-port: '80'
     dapr.io/config: 'tracing'
     dapr.io/log-level: 'debug'
   labels:
@@ -20,8 +20,8 @@ spec:
     metadata:
       annotations:
         dapr.io/enabled: 'true'
-        dapr.io/id: 'dapr-test-project'
-        dapr.io/port: '80'
+        dapr.io/app-id: 'dapr-test-project'
+        dapr.io/app-port: '80'
         dapr.io/config: 'tracing'
         dapr.io/log-level: 'debug'
       labels:


### PR DESCRIPTION
Dapr v1.0.0-rc-1 introduced following [breaking change](https://github.com/dapr/dapr/blob/release-1.0/docs/release_notes/v1.0.0-rc.1.md#breaking-changes):

> The following annotations are no longer supported:
> 
> * `dapr.io/id`
> * `dapr.io/port`
> * `dapr.io/protocol`
> 
> Instead, use the following:
> 
> * `dapr.io/app-id`
> * `dapr.io/app-port`
> * `dapr.io/app-protocol`

This PR fixes the renamed annotations when deploying with Tye to k8s.