### PR TITLE
Handle project evaluation target path with spaces

### DIFF
--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -516,16 +516,17 @@ namespace Microsoft.Tye
 
             output.WriteDebugLine("Restoring and evaluating projects");
 
+            var projectEvaluationTargets = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "ProjectEvaluation.targets");
             var msbuildEvaluationResult = await ProcessUtil.RunAsync(
                 "dotnet",
                 $"build " +
                     $"\"{projectPath}\" " +
                     // CustomAfterMicrosoftCommonTargets is imported by non-crosstargeting (single TFM) projects
-                    $"/p:CustomAfterMicrosoftCommonTargets={Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "ProjectEvaluation.targets")} " +
+                    @$"/p:CustomAfterMicrosoftCommonTargets=""{projectEvaluationTargets}"" " +
                     // CustomAfterMicrosoftCommonCrossTargetingTargets is imported by crosstargeting (multi-TFM) projects
                     // This ensures projects properties are evaluated correctly. However, multi-TFM projects must specify
                     // a specific TFM to build/run/publish and will otherwise throw an exception.
-                    $"/p:CustomAfterMicrosoftCommonCrossTargetingTargets={Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "ProjectEvaluation.targets")} " +
+                    @$"/p:CustomAfterMicrosoftCommonCrossTargetingTargets=""{projectEvaluationTargets}"" " +
                     $"/nologo",
                 throwOnError: false,
                 workingDirectory: directory.DirectoryPath);


### PR DESCRIPTION
Fixes https://github.com/dotnet/tye/issues/766. 

The issue is that if tye is installed in a directory path with spaces, such as when user profile contained spaces, the project evaluation command was broken. The fix is to add quotation marks around the path.

It's a bit hard to construct an unit test for this since tye needs to be installed in a special directory but I've verified this manually.