### PR TITLE
Ensure watched projects are not built in parallel to avoid file locking issues

### DIFF
--- a/src/Microsoft.Tye.Hosting/Model/Application.cs
+++ b/src/Microsoft.Tye.Hosting/Model/Application.cs
@@ -3,11 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Tye.Hosting.Model
 {
@@ -18,18 +19,6 @@ namespace Microsoft.Tye.Hosting.Model
             Source = source.FullName;
             ContextDirectory = source.DirectoryName!;
             Services = services;
-
-            foreach (var s in Services.Values)
-            {
-                if (s.Description.RunInfo is ProjectRunInfo projectRunInfo)
-                {
-                    var projectFileName = projectRunInfo.ProjectFile.FullName;
-                    if (!ProjectFileLocks.ContainsKey(projectFileName))
-                    {
-                        ProjectFileLocks[projectFileName] = new SemaphoreSlim(1, 1);
-                    }
-                }
-            }
         }
 
         public string Source { get; }
@@ -38,7 +27,7 @@ namespace Microsoft.Tye.Hosting.Model
 
         public Dictionary<string, Service> Services { get; }
 
-        internal Dictionary<string, SemaphoreSlim> ProjectFileLocks { get; } = new Dictionary<string, SemaphoreSlim>();
+        internal ConcurrentDictionary<string, TaskCompletionSource<ProcessResult>> ProjectProcesses { get; } = new ConcurrentDictionary<string, TaskCompletionSource<ProcessResult>>();
 
         public Dictionary<object, object> Items { get; } = new Dictionary<object, object>();
 

--- a/src/Microsoft.Tye.Hosting/Model/Application.cs
+++ b/src/Microsoft.Tye.Hosting/Model/Application.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Tye.Hosting.Model
 
         public Dictionary<string, Service> Services { get; }
 
-        internal ConcurrentDictionary<string, TaskCompletionSource<ProcessResult>> ProjectProcesses { get; } = new ConcurrentDictionary<string, TaskCompletionSource<ProcessResult>>();
+        internal ConcurrentDictionary<string, TaskCompletionSource<ProcessResult>> OngoingBuildProjectProcesses { get; }
+            = new ConcurrentDictionary<string, TaskCompletionSource<ProcessResult>>();
 
         public Dictionary<object, object> Items { get; } = new Dictionary<object, object>();
 

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -363,7 +363,7 @@ namespace Microsoft.Tye.Hosting
                                 {
                                     var projectFile = projectRunInfo.ProjectFile.FullName;
                                     var newProcess = new TaskCompletionSource<ProcessResult>();
-                                    var ongoingProcess = application.ProjectProcesses.GetOrAdd(projectFile, newProcess);
+                                    var ongoingProcess = application.OngoingBuildProjectProcesses.GetOrAdd(projectFile, newProcess);
 
                                     if (ongoingProcess != newProcess)
                                     {
@@ -377,7 +377,7 @@ namespace Microsoft.Tye.Hosting
                                     ongoingProcess.SetResult(buildResult);
 
                                     // Cannot remove a specific KVP until net5.0. Workaround is to cast to ICollection<KVP<>>
-                                    ICollection<KeyValuePair<string, TaskCompletionSource<ProcessResult>>> projectProcesses = application.ProjectProcesses;
+                                    ICollection<KeyValuePair<string, TaskCompletionSource<ProcessResult>>> projectProcesses = application.OngoingBuildProjectProcesses;
                                     projectProcesses.Remove(KeyValuePair.Create(projectFile, ongoingProcess));
 
                                     if (buildResult.ExitCode != 0)

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -367,12 +367,13 @@ namespace Microsoft.Tye.Hosting
 
                                     if (ongoingProcess != newProcess)
                                     {
+                                        _logger.LogDebug($"[{replica}] A build has already been triggered for project {projectFile}");
                                         return (await ongoingProcess.Task).ExitCode;
                                     }
 
-                                    _logger.LogDebug($"[{replica}] Building project {projectFile}:");
+                                    _logger.LogDebug($"[{replica}] Building project {projectFile}");
                                     var buildResult = await ProcessUtil.RunAsync("dotnet", $"build \"{service.Status.ProjectFilePath}\" /nologo", throwOnError: false, workingDirectory: application.ContextDirectory);
-                                    _logger.LogDebug($"[{replica}] Finished Building project {projectFile}:");
+                                    _logger.LogDebug($"[{replica}] Finished Building project {projectFile}");
 
                                     ongoingProcess.SetResult(buildResult);
 

--- a/src/Microsoft.Tye.Hosting/Watch/DotNetWatcher.cs
+++ b/src/Microsoft.Tye.Hosting/Watch/DotNetWatcher.cs
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Watcher
                     if (finishedTask == processTask)
                     {
                         // Now wait for a file to change before restarting process
-                        await fileSetWatcher.GetChangedFileAsync(cancellationToken, () => _logger.LogWarning("Waiting for a file to change before restarting dotnet..."));
+                        await fileSetWatcher.GetChangedFileAsync(cancellationToken, () => _logger.LogWarning("watch: {Replica} Waiting for a file to change before restarting dotnet...", replica));
                     }
 
                     if (!string.IsNullOrEmpty(fileSetTask.Result))
@@ -112,7 +112,8 @@ namespace Microsoft.DotNet.Watcher
                                 // Build failed, keep retrying builds until successful build. 
                             }
 
-                            await fileSetWatcher.GetChangedFileAsync(cancellationToken, () => _logger.LogWarning("Waiting for a file to change before restarting dotnet..."));
+                            // Now wait for a file to change before restarting process
+                            await fileSetWatcher.GetChangedFileAsync(cancellationToken, () => _logger.LogWarning("watch: {Replica} Waiting for a file to change before restarting dotnet...", replica));
                         }
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/tye/issues/580.

I've experimented with several approaches and this seems the most general. One of the drawbacks is that if there are multiple services that are based on the same project file, re-running build on all of them will now be much slower. However, I'm skeptical of running build once and re-using the results since the files could have changed during the time the project was built the first time. Ideally we would track what file changes have been accounted for and whether builds need to be re-run but I don't think the file watcher has that capability at the momennt.