### PR TITLE
Fix tye init --force

### DIFF
--- a/activate.ps1
+++ b/activate.ps1
@@ -13,7 +13,6 @@ if ($MyInvocation.CommandOrigin -eq 'runspace') {
 
 function dtye() {
     $ProjectPath = Join-Path (Join-Path $PSScriptRoot "src") "tye"
-    Write-Host dotnet run --project "$ProjectPath" -- @args
     dotnet run --project "$ProjectPath" -- @args
 }
 

--- a/activate.ps1
+++ b/activate.ps1
@@ -13,7 +13,8 @@ if ($MyInvocation.CommandOrigin -eq 'runspace') {
 
 function dtye() {
     $ProjectPath = Join-Path (Join-Path $PSScriptRoot "src") "tye"
-    dotnet run --project "$ProjectPath" @args
+    Write-Host dotnet run --project "$ProjectPath" -- @args
+    dotnet run --project "$ProjectPath" -- @args
 }
 
 function deactivate ([switch]$init) {

--- a/src/Microsoft.Tye.Core/ConfigFileFinder.cs
+++ b/src/Microsoft.Tye.Core/ConfigFileFinder.cs
@@ -10,9 +10,10 @@ namespace Microsoft.Tye
     {
         private static readonly string[] FileFormats = { "tye.yaml", "tye.yml", "docker-compose.yaml", "docker-compose.yml", "*.csproj", "*.fsproj", "*.sln" };
 
-        public static bool TryFindSupportedFile(string directoryPath, out string? filePath, out string? errorMessage)
+        public static bool TryFindSupportedFile(string directoryPath, out string? filePath, out string? errorMessage, string[]? fileFormats = null)
         {
-            foreach (var format in FileFormats)
+            fileFormats ??= FileFormats;
+            foreach (var format in fileFormats)
             {
                 var files = Directory.GetFiles(directoryPath, format);
 

--- a/src/tye/InitHost.cs
+++ b/src/tye/InitHost.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Tye
             {
                 // Don't use existing tye.yaml if we are force creating it again.
                 // path prior is pointing to the tye.yaml file still, so refind another file that isn't the tye.yaml
-                var hasViableFileType = ConfigFileFinder.TryFindSupportedFile(path.DirectoryName ?? ".",
+                var hasViableFileType = ConfigFileFinder.TryFindSupportedFile(path?.DirectoryName ?? ".",
                     out var filePath,
                     out var errorMessage,
                     new string[] { "*.csproj", "*.fsproj", "*.sln" });

--- a/src/tye/InitHost.cs
+++ b/src/tye/InitHost.cs
@@ -23,6 +23,23 @@ namespace Microsoft.Tye
                 ThrowIfTyeFilePresent(path, "tye.yaml");
             }
 
+            if (force)
+            {
+                // Don't use existing tye.yaml if we are force creating it again.
+                // path prior is pointing to the tye.yaml file still, so refind another file that isn't the tye.yaml
+                var hasViableFileType = ConfigFileFinder.TryFindSupportedFile(path.DirectoryName,
+                    out var filePath,
+                    out var errorMessage,
+                    new string[] {"*.csproj", "*.fsproj", "*.sln" });
+
+                if (!hasViableFileType)
+                {
+                    throw new CommandException(errorMessage!);
+                }
+
+                path = new FileInfo(filePath);
+            }
+
             var template = @"
 # tye application configuration file
 # read all about it at https://github.com/dotnet/tye

--- a/src/tye/InitHost.cs
+++ b/src/tye/InitHost.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Tye
                 var hasViableFileType = ConfigFileFinder.TryFindSupportedFile(path.DirectoryName,
                     out var filePath,
                     out var errorMessage,
-                    new string[] {"*.csproj", "*.fsproj", "*.sln" });
+                    new string[] { "*.csproj", "*.fsproj", "*.sln" });
 
                 if (!hasViableFileType)
                 {

--- a/src/tye/InitHost.cs
+++ b/src/tye/InitHost.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Tye
             {
                 // Don't use existing tye.yaml if we are force creating it again.
                 // path prior is pointing to the tye.yaml file still, so refind another file that isn't the tye.yaml
-                var hasViableFileType = ConfigFileFinder.TryFindSupportedFile(path.DirectoryName,
+                var hasViableFileType = ConfigFileFinder.TryFindSupportedFile(path.DirectoryName ?? ".",
                     out var filePath,
                     out var errorMessage,
                     new string[] { "*.csproj", "*.fsproj", "*.sln" });

--- a/test/E2ETest/TyeInitTests.cs
+++ b/test/E2ETest/TyeInitTests.cs
@@ -89,5 +89,20 @@ namespace E2ETest
 
             YamlAssert.Equals(expectedContent, content);
         }
+
+        [Fact]
+        public void Tye_Init_Force_Works()
+        {
+            using var projectDirectory = CopyTestProjectDirectory("single-project");
+            var tyePath = Path.Combine(projectDirectory.DirectoryPath, "tye.yaml");
+            var text = File.ReadAllText(tyePath);
+            File.WriteAllText(tyePath, text + "thisisatest");
+
+            var projectFile = new FileInfo(tyePath);
+
+            var (content, _) = InitHost.CreateTyeFileContent(projectFile, force: true);
+
+            Assert.DoesNotContain("thisisatest", content);
+        }
     }
 }


### PR DESCRIPTION
Addresses https://github.com/dotnet/tye/issues/894

Also fixes dtye to have arguments.

When we run tye init --force, if there is a present tye.yaml file, it will still be used as the slate for building the application model, rather than  other files like the sln or csproj that should be used. This reruns discovery on file types other than tye.yaml.