### PR TITLE
PoC Add "control plane" method to shutdown Tye application

### DIFF
--- a/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
+++ b/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Tye.Hosting
         public void MapRoutes(IEndpointRouteBuilder endpoints)
         {
             endpoints.MapGet("/api/v1", ServiceIndex);
-            endpoints.MapPut("/api/v1/control/shutdown", ControlPlaneShutdown);
+            endpoints.MapDelete("/api/v1/control", ControlPlaneShutdown);
             endpoints.MapGet("/api/v1/services", Services);
             endpoints.MapGet("/api/v1/services/{name}", Service);
             endpoints.MapGet("/api/v1/logs/{name}", Logs);


### PR DESCRIPTION
Adds a dashboard "control plane" endpoint that allows shutting down the Tye application.

Related to #898.