### PR TITLE
Add X-Forwarded-* headers for request proxying in ingress nodes

### DIFF
--- a/src/Microsoft.Tye.Hosting/Infrastructure/ProxyExtensions.cs
+++ b/src/Microsoft.Tye.Hosting/Infrastructure/ProxyExtensions.cs
@@ -204,14 +204,7 @@ namespace Microsoft.AspNetCore.Proxy
             }
 
             // Append Via header so clients are aware of reverse-proxying.
-            if (response.Headers.TryGetValue("Via", out var via))
-            {
-                via.Append($"{responseMessage.Version} Tye");
-            }
-            else
-            {
-                response.Headers["Via"] = new[] { $"{responseMessage.Version} Tye" };
-            }
+            response.Headers.AppendCommaSeparatedValues("Via", $"{responseMessage.Version} Tye");
 
             // SendAsync removes chunking from the response. This removes the header so it doesn't expect a chunked response.
             response.Headers.Remove("transfer-encoding");

--- a/src/Microsoft.Tye.Hosting/Infrastructure/ProxyExtensions.cs
+++ b/src/Microsoft.Tye.Hosting/Infrastructure/ProxyExtensions.cs
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Proxy
 
             // Append request forwarding headers
             requestMessage.Headers.TryAddWithoutValidation("Via", $"{context.Request.Protocol} Tye");
-            requestMessage.Headers.TryAddWithoutValidation("X-Forwarded-For", context.Connection.LocalIpAddress.ToString());
+            requestMessage.Headers.TryAddWithoutValidation("X-Forwarded-For", context.Connection.RemoteIpAddress.ToString());
             requestMessage.Headers.TryAddWithoutValidation("X-Forwarded-Proto", request.Scheme);
             requestMessage.Headers.TryAddWithoutValidation("X-Forwarded-Host", request.Host.ToUriComponent());
 
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.Proxy
             }
 
             AppendHeaderValue(client.Options, context.Request.Headers, "Via", context.Request.Protocol);
-            AppendHeaderValue(client.Options, context.Request.Headers, "X-Forwarded-For", context.Connection.LocalIpAddress.ToString());
+            AppendHeaderValue(client.Options, context.Request.Headers, "X-Forwarded-For", context.Connection.RemoteIpAddress.ToString());
             AppendHeaderValue(client.Options, context.Request.Headers, "X-Forwarded-Proto", context.Request.Scheme);
             AppendHeaderValue(client.Options, context.Request.Headers, "X-Forwarded-Host", context.Request.Host.ToUriComponent());
 

--- a/src/Microsoft.Tye.Hosting/Infrastructure/ProxyExtensions.cs
+++ b/src/Microsoft.Tye.Hosting/Infrastructure/ProxyExtensions.cs
@@ -8,12 +8,13 @@ using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Proxy
 {
     internal static class ProxyAdvancedExtensions
     {
-        private static readonly string[] NotForwardedWebSocketHeaders = new[] { "Connection", "Host", "Upgrade", "Sec-WebSocket-Accept", "Sec-WebSocket-Protocol", "Sec-WebSocket-Key", "Sec-WebSocket-Version", "Sec-WebSocket-Extensions" };
+        private static readonly string[] NotForwardedWebSocketHeaders = new[] { "Connection", "Host", "Upgrade", "Sec-WebSocket-Accept", "Sec-WebSocket-Protocol", "Sec-WebSocket-Key", "Sec-WebSocket-Version", "Sec-WebSocket-Extensions", "Via", "X-Forwarded-For", "X-Forwarded-Proto", "X-Forwarded-Host" };
         private const int DefaultWebSocketBufferSize = 4096;
         private const int StreamCopyBufferSize = 81920;
 
@@ -86,6 +87,7 @@ namespace Microsoft.AspNetCore.Proxy
             }
 
             // Append request forwarding headers
+            requestMessage.Headers.TryAddWithoutValidation("Via", $"{context.Request.Protocol} Tye");
             requestMessage.Headers.TryAddWithoutValidation("X-Forwarded-For", context.Connection.LocalIpAddress.ToString());
             requestMessage.Headers.TryAddWithoutValidation("X-Forwarded-Proto", request.Scheme);
             requestMessage.Headers.TryAddWithoutValidation("X-Forwarded-Host", request.Host.ToUriComponent());
@@ -126,6 +128,11 @@ namespace Microsoft.AspNetCore.Proxy
                 }
             }
 
+            AppendHeaderValue(client.Options, context.Request.Headers, "Via", context.Request.Protocol);
+            AppendHeaderValue(client.Options, context.Request.Headers, "X-Forwarded-For", context.Connection.LocalIpAddress.ToString());
+            AppendHeaderValue(client.Options, context.Request.Headers, "X-Forwarded-Proto", context.Request.Scheme);
+            AppendHeaderValue(client.Options, context.Request.Headers, "X-Forwarded-Host", context.Request.Host.ToUriComponent());
+
             try
             {
                 await client.ConnectAsync(destinationUri, context.RequestAborted);
@@ -142,6 +149,12 @@ namespace Microsoft.AspNetCore.Proxy
             await Task.WhenAll(PumpWebSocket(client, server, bufferSize, context.RequestAborted), PumpWebSocket(server, client, bufferSize, context.RequestAborted));
 
             return true;
+
+            static void AppendHeaderValue(ClientWebSocketOptions options, IHeaderDictionary headers, string key, string value)
+            {
+                var newValue = new StringValues(headers[key].Append(value).ToArray());
+                options.SetRequestHeader(key, newValue);
+            }
         }
 
         private static async Task PumpWebSocket(WebSocket source, WebSocket destination, int bufferSize, CancellationToken cancellationToken)
@@ -202,9 +215,6 @@ namespace Microsoft.AspNetCore.Proxy
             {
                 response.Headers[header.Key] = header.Value.ToArray();
             }
-
-            // Append Via header so clients are aware of reverse-proxying.
-            response.Headers.AppendCommaSeparatedValues("Via", $"{responseMessage.Version} Tye");
 
             // SendAsync removes chunking from the response. This removes the header so it doesn't expect a chunked response.
             response.Headers.Remove("transfer-encoding");


### PR DESCRIPTION
Previously, Tye's ingress proxy wouldn't add X-Forwarded-* headers to its proxied requests, making anything which depends on the Host header for the request (e.g. OAuth redirect URIs, CORS origins, etc.) almost impossible. This PR adds those headers to proxied requests, so that reverse proxying more or less "just works" using more or less standard ASP.NET forwarded headers.

For example:
```cs
// ConfigureServices
services.Configure<ForwardedHeadersOptions>(options =>
    {
        options.ForwardedHeaders = ForwardedHeaders.All;
        options.KnownProxies.Add(IPAddress.Loopback);
        options.KnownProxies.Add(IPAddress.IPv6Loopback);
        options.RequireHeaderSymmetry = true;
    });

// Configure
app.UseForwardedHeaders();
```

I have not yet added these to proxied websocket requests, because I'm not 100% sure how proxying works for those :sweat_smile: 