### PR TITLE
Fix #901 - Executes git clone, based on the tye.yaml directory.

### DIFF
--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Tye
                     else if (!string.IsNullOrEmpty(configService.Repository))
                     {
                         // clone to .tye folder
-                        var path = configService.CloneDirectory ?? Path.Join(rootConfig.Source.DirectoryName, ".tye", "deps");
+                        var path = configService.CloneDirectory ?? Path.Join(".tye", "deps");
                         if (!Directory.Exists(path))
                         {
                             Directory.CreateDirectory(path);
@@ -282,7 +282,7 @@ namespace Microsoft.Tye
                                 throw new CommandException($"Cannot clone repository {configService.Repository} because git is not installed. Please install git if you'd like to use \"repository\" in tye.yaml.");
                             }
 
-                            var result = await ProcessUtil.RunAsync("git", $"clone {configService.Repository} \"{clonePath}\"", workingDirectory: path, throwOnError: false);
+                            var result = await ProcessUtil.RunAsync("git", $"clone {configService.Repository} \"{clonePath}\"", workingDirectory: rootConfig.Source.DirectoryName, throwOnError: false);
 
                             if (result.ExitCode != 0)
                             {

--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Tye
                             Directory.CreateDirectory(path);
                         }
 
-                        var clonePath = Path.Combine(path, configService.Name);
+                        var clonePath = Path.Combine(rootConfig.Source.DirectoryName!, path, configService.Name);
 
                         if (!Directory.Exists(clonePath))
                         {


### PR DESCRIPTION
With this fix, all variants should have been considered.

It was tested on a Windows system.

- Service without `cloneDirectory` property
- Service with absolute `cloneDirectory`property
- Service with relative `cloneDirectory`property