### PR TITLE
Fixing Env var for dapr on unix

### DIFF
--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -279,7 +279,7 @@ namespace Microsoft.Tye.Extensions.Dapr
             }
             else
             {
-                var nixpath = Environment.ExpandEnvironmentVariables("$HOME/.dapr/bin/daprd");
+                var nixpath = Environment.ExpandEnvironmentVariables("%HOME%/.dapr/bin/daprd");
                 if (File.Exists(nixpath))
                 {
                     return nixpath;


### PR DESCRIPTION
Apparently it needs % encoded env vars, even on unix...

Verified on ubuntu.