### PR TITLE
Bind port in docker with udp flag when protocol is udp

### DIFF
--- a/src/Microsoft.Tye.Hosting/DockerRunner.cs
+++ b/src/Microsoft.Tye.Hosting/DockerRunner.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Tye.Hosting
                     // These are the ports that the application should use for binding
 
                     // 1. Tell the docker container what port to bind to
-                    portString = docker.Private ? "" : string.Join(" ", ports.Select(p => $"-p {p.Port}:{p.ContainerPort ?? p.Port}"));
+                    portString = docker.Private ? "" : string.Join(" ", ports.Select(p => $"-p {p.Port}:{p.ContainerPort ?? p.Port}{(p.Protocol == "udp" ? "/udp" : string.Empty)}"));
 
                     if (docker.IsAspNet)
                     {


### PR DESCRIPTION
This change allows setting the protocol of a port of an image service to udp, which will bind the port with the udp flag in docker.

Notes: 
- I didn't know if I should handle it case-insensitive, it currently only works when the protocol is set to lowercase udp
- I couldn't find any unit tests or end-to-end tests in this area, so I didn't add any either
- Possibly it is preferred to add this to the port field instead of the protocol field (e.g. `port: 6831/udp`). if it is, I can update this PR accordingly

I needed this when I tried to use jeager:
```
name: jaeger-sample
services:
- name: jaeger
  image: jaegertracing/all-in-one:1.21
  bindings:
  - name: compact
    port: 6831
    protocol: udp
  - name: frontend
    port: 16686
```

This PR solves https://github.com/dotnet/tye/issues/658 and https://github.com/dotnet/tye/issues/839 .
