### PR TITLE
Handle plus signs in Kubernetes minor version

### DIFF
--- a/src/shared/KubectlDetector.cs
+++ b/src/shared/KubectlDetector.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Tye
                         continue;
                     }
                     var major = int.Parse(element.Value.GetProperty("major").GetString());
-                    var minor = int.Parse(element.Value.GetProperty("minor").GetString());
+                    var minor = int.Parse(element.Value.GetProperty("minor").GetString().Trim('+'));
                     var version = new Version(major, minor);
                     return version;
                 }


### PR DESCRIPTION
Resolves #927
Resolves #943

This PR updates Tye's KubectlDetector to handle plus signs in the minor version instead of returning an error message.

kubectl version -o json
```
{
  "clientVersion": {
    "major": "1",
    "minor": "20",
    "gitVersion": "v1.20.2",
    "gitCommit": "faecb196815e248d3ecfb03c680a4507229c2a56",
    "gitTreeState": "clean",
    "buildDate": "2021-01-13T13:28:09Z",
    "goVersion": "go1.15.5",
    "compiler": "gc",
    "platform": "linux/amd64"
  },
  "serverVersion": {
    "major": "1",
    "minor": "20+",
    "gitVersion": "v1.20.1-34+e7db93d188d0d1",
    "gitCommit": "e7db93d188d0d12f2fe5336d1b85cdb94cb909d3",
    "gitTreeState": "clean",
    "buildDate": "2021-01-11T23:50:46Z",
    "goVersion": "go1.15.6",
    "compiler": "gc",
    "platform": "linux/amd64"
  }
}
```

This line is the problem:
```
"minor": "20+",
```