### PR TITLE
Enhance Elastic extension for configurable ports

### DIFF
--- a/src/Microsoft.Tye.Extensions/Elastic/ElasticStackExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Elastic/ElasticStackExtension.cs
@@ -10,10 +10,12 @@ namespace Microsoft.Tye.Extensions.Elastic
 {
     internal sealed class ElasticStackExtension : Extension
     {
+        const int DEFAULT_PORT_ELASTIC = 9200;
+        const int DEFAULT_PORT_KIBANA = 5601;
         public override Task ProcessAsync(ExtensionContext context, ExtensionConfiguration config)
         {
-            var elasticPort = GetIntValueFromConfigData(config, "port", 9200);
-            var kibanaPort = GetIntValueFromConfigData(config, "port-kibana", 5601);
+            var elasticPort = GetIntValueFromConfigData(config, "port", DEFAULT_PORT_ELASTIC);
+            var kibanaPort = GetIntValueFromConfigData(config, "port-kibana", DEFAULT_PORT_KIBANA);
 
             if (context.Application.Services.Any(s => s.Name == "elastic"))
             {
@@ -35,13 +37,13 @@ namespace Microsoft.Tye.Extensions.Elastic
                         {
                             Name = "kibana",
                             Port = kibanaPort,
-                            ContainerPort = kibanaPort,
+                            ContainerPort = DEFAULT_PORT_KIBANA,
                             Protocol = "http",
                         },
                         new BindingBuilder()
                         {
                             Port = elasticPort,
-                            ContainerPort = elasticPort,
+                            ContainerPort = DEFAULT_PORT_ELASTIC,
                             Protocol = "http",
                         },
                     },

--- a/src/Microsoft.Tye.Extensions/Elastic/ElasticStackExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Elastic/ElasticStackExtension.cs
@@ -12,6 +12,10 @@ namespace Microsoft.Tye.Extensions.Elastic
     {
         public override Task ProcessAsync(ExtensionContext context, ExtensionConfiguration config)
         {
+            var elasticPort = 9200;
+            var elasticContainerPort = 9200;
+            var kibanaPort = 5601;
+            var kibanaContainerPort = 5601;
             if (context.Application.Services.Any(s => s.Name == "elastic"))
             {
                 context.Output.WriteDebugLine("elastic service already configured. Skipping...");
@@ -31,14 +35,14 @@ namespace Microsoft.Tye.Extensions.Elastic
                         new BindingBuilder()
                         {
                             Name = "kibana",
-                            Port = 5601,
-                            ContainerPort = 5601,
+                            Port = kibanaPort,
+                            ContainerPort = kibanaContainerPort,
                             Protocol = "http",
                         },
                         new BindingBuilder()
                         {
-                            Port = 9200,
-                            ContainerPort = 9200,
+                            Port = elasticPort,
+                            ContainerPort = elasticContainerPort,
                             Protocol = "http",
                         },
                     },
@@ -75,7 +79,7 @@ namespace Microsoft.Tye.Extensions.Elastic
                         if (context.Options!.LoggingProvider is null)
                         {
                             // For local development we hardcode the port and hostname
-                            context.Options.LoggingProvider = "elastic=http://localhost:9200";
+                            context.Options.LoggingProvider = $"elastic=http://localhost:{elasticPort}";
                         }
 
                         break;

--- a/src/Microsoft.Tye.Extensions/Elastic/ElasticStackExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Elastic/ElasticStackExtension.cs
@@ -12,10 +12,9 @@ namespace Microsoft.Tye.Extensions.Elastic
     {
         public override Task ProcessAsync(ExtensionContext context, ExtensionConfiguration config)
         {
-            var elasticPort = 9200;
-            var elasticContainerPort = 9200;
-            var kibanaPort = 5601;
-            var kibanaContainerPort = 5601;
+            var elasticPort = GetIntValueFromConfigData(config, "port", 9200);
+            var kibanaPort = GetIntValueFromConfigData(config, "port-kibana", 5601);
+
             if (context.Application.Services.Any(s => s.Name == "elastic"))
             {
                 context.Output.WriteDebugLine("elastic service already configured. Skipping...");
@@ -36,13 +35,13 @@ namespace Microsoft.Tye.Extensions.Elastic
                         {
                             Name = "kibana",
                             Port = kibanaPort,
-                            ContainerPort = kibanaContainerPort,
+                            ContainerPort = kibanaPort,
                             Protocol = "http",
                         },
                         new BindingBuilder()
                         {
                             Port = elasticPort,
-                            ContainerPort = elasticContainerPort,
+                            ContainerPort = elasticPort,
                             Protocol = "http",
                         },
                     },
@@ -108,6 +107,15 @@ namespace Microsoft.Tye.Extensions.Elastic
             }
 
             return Task.CompletedTask;
+        }
+
+        private static int? GetIntValueFromConfigData(ExtensionConfiguration config, string key, int defaultValue)
+        {
+            if (config.Data.TryGetValue(key, out var obj) && int.TryParse(obj?.ToString(), out int parsedValue))
+            {
+                return parsedValue;
+            }
+            return defaultValue;
         }
     }
 }

--- a/src/Microsoft.Tye.Extensions/Elastic/ElasticStackExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Elastic/ElasticStackExtension.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Tye.Extensions.Elastic
 
         private static int? GetIntValueFromConfigData(ExtensionConfiguration config, string key, int defaultValue)
         {
-            if (config.Data.TryGetValue(key, out var obj) && int.TryParse(obj?.ToString(), out int parsedValue))
+            if (config.Data.TryGetValue(key, out var obj) && obj is not null && int.TryParse(obj.ToString(), out int parsedValue))
             {
                 return parsedValue;
             }


### PR DESCRIPTION
Proposal for #937 

Sample usage (tye.yaml)
```
name: tye_hello_world
registry: localhost:5000
extensions:
- name: elastic
  logPath: ./.logs
  port: 11000
services:
- name: frontend
  project: frontend/frontend.csproj
- name: backend
  project: backend/backend.csproj
  ```
  
  This allows you to work around scenarios where the default ports (`5601` and `9200`) are locked down by an administrator.