### PR TITLE
Flush  ProcessUtil buffer

### DIFF
--- a/src/Microsoft.Tye.Core/ProcessUtil.cs
+++ b/src/Microsoft.Tye.Core/ProcessUtil.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Tye
                 // Even though the Exited event has been raised, WaitForExit() must still be called to ensure the output buffers
                 // have been flushed before the process is considered completely done.
                 process.WaitForExit();
-                
+
                 if (throwOnError && process.ExitCode != 0)
                 {
                     processLifetimeTask.TrySetException(new InvalidOperationException($"Command {filename} {arguments} returned exit code {process.ExitCode}"));

--- a/src/Microsoft.Tye.Core/ProcessUtil.cs
+++ b/src/Microsoft.Tye.Core/ProcessUtil.cs
@@ -103,6 +103,10 @@ namespace Microsoft.Tye
 
             process.Exited += (_, e) =>
             {
+                // Even though the Exited event has been raised, WaitForExit() must still be called to ensure the output buffers
+                // have been flushed before the process is considered completely done.
+                process.WaitForExit();
+                
                 if (throwOnError && process.ExitCode != 0)
                 {
                     processLifetimeTask.TrySetException(new InvalidOperationException($"Command {filename} {arguments} returned exit code {process.ExitCode}"));


### PR DESCRIPTION
/cc @mikeharder who found the bug in crank

Some log might be lost because `WaitForExit()` is never called and the internal stdout/err buffers are not flushed. 