### PR TITLE
Recipes - fixed invalid port in Dapr sample code

### DIFF
--- a/docs/recipes/dapr.md
+++ b/docs/recipes/dapr.md
@@ -88,7 +88,7 @@ services:
 - name: redis
   image: redis
   bindings:
-    - port: 6973
+    - port: 6379
 ``` 
 
 All that's needed to enable Dapr integration for an application is:


### PR DESCRIPTION
The Redis port is correct in the Dapr sample app, but it's incorrect in this recipe page.