### PR TITLE
#965 change dapr startup from daprd to dapr CLI

### DIFF
--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Tye.Extensions.Dapr
 
                         // These environment variables are replaced with environment variables
                         // defined for this service.
-                        Args = $"-app-id {project.Name} -app-port %APP_PORT% -dapr-grpc-port %DAPR_GRPC_PORT% --dapr-http-port %DAPR_HTTP_PORT% --metrics-port %METRICS_PORT% --placement-host-address localhost:{daprPlacementPort}",
+                        Args = $"run -app-id {project.Name} -app-port %APP_PORT% -dapr-grpc-port %DAPR_GRPC_PORT% --dapr-http-port %DAPR_HTTP_PORT% --metrics-port %METRICS_PORT% --placement-host-address localhost:{daprPlacementPort}",
                     };
 
                     // When running locally `-config` specifies a filename, not a configuration name. By convention
@@ -271,7 +271,7 @@ namespace Microsoft.Tye.Extensions.Dapr
             // Starting with dapr version 11, dapr is installed in user profile/home.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var windowsPath = Environment.ExpandEnvironmentVariables("%USERPROFILE%/.dapr/bin/daprd.exe");
+                var windowsPath = Environment.ExpandEnvironmentVariables("%HOMEDRIVE%/dapr/dapr.exe");
                 if (File.Exists(windowsPath))
                 {
                     return windowsPath;
@@ -279,7 +279,7 @@ namespace Microsoft.Tye.Extensions.Dapr
             }
             else
             {
-                var nixpath = Environment.ExpandEnvironmentVariables("%HOME%/.dapr/bin/daprd");
+                var nixpath = "/usr/local/bin/dapr";
                 if (File.Exists(nixpath))
                 {
                     return nixpath;
@@ -287,7 +287,7 @@ namespace Microsoft.Tye.Extensions.Dapr
             }
 
             // Older version of dapr don't have dapr in the bin directory, but it is usually on the path.
-            return "daprd";
+            return "dapr";
         }
     }
 }


### PR DESCRIPTION
This PR:
- replaces the `daprd` startup with dapr CLI in order to have the `dapr dashboard` detect dapr services started with Tye as described in #965 