### PR TITLE
Fixes to dapr.exe cmdline invocation

### DIFF
--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -107,7 +107,8 @@ namespace Microsoft.Tye.Extensions.Dapr
 
                         // These environment variables are replaced with environment variables
                         // defined for this service.
-                        Args = $"run -app-id {project.Name} -app-port %APP_PORT% -dapr-grpc-port %DAPR_GRPC_PORT% --dapr-http-port %DAPR_HTTP_PORT% --metrics-port %METRICS_PORT% --placement-host-address localhost:{daprPlacementPort}",
+                        // Note: --metrics-port %METRICS_PORT% is not supported by dapr.exe
+                        Args = $"run --app-id {project.Name} --app-port %APP_PORT% --dapr-grpc-port %DAPR_GRPC_PORT% --dapr-http-port %DAPR_HTTP_PORT% --placement-host-address localhost:{daprPlacementPort}",
                     };
 
                     // When running locally `-config` specifies a filename, not a configuration name. By convention
@@ -117,7 +118,7 @@ namespace Microsoft.Tye.Extensions.Dapr
                         var configFile = Path.Combine(context.Application.Source.DirectoryName!, "components", $"{daprConfig}.yaml");
                         if (File.Exists(configFile))
                         {
-                            proxy.Args += $" -config \"{configFile}\"";
+                            proxy.Args += $" --config \"{configFile}\"";
                         }
                         else
                         {
@@ -127,12 +128,12 @@ namespace Microsoft.Tye.Extensions.Dapr
 
                     if (config.Data.TryGetValue("log-level", out obj) && obj?.ToString() is string logLevel)
                     {
-                        proxy.Args += $" -log-level {logLevel}";
+                        proxy.Args += $" --log-level {logLevel}";
                     }
 
                     if (config.Data.TryGetValue("components-path", out obj) && obj?.ToString() is string componentsPath)
                     {
-                        proxy.Args += $" -components-path {componentsPath}";
+                        proxy.Args += $" --components-path {componentsPath}";
                     }
                     // Add dapr proxy as a service available to everyone.
                     proxy.Dependencies.UnionWith(context.Application.Services.Select(s => s.Name));

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -107,8 +107,7 @@ namespace Microsoft.Tye.Extensions.Dapr
 
                         // These environment variables are replaced with environment variables
                         // defined for this service.
-                        // Note: --metrics-port %METRICS_PORT% is not supported by dapr.exe
-                        Args = $"run --app-id {project.Name} --app-port %APP_PORT% --dapr-grpc-port %DAPR_GRPC_PORT% --dapr-http-port %DAPR_HTTP_PORT% --placement-host-address localhost:{daprPlacementPort}",
+                        Args = $"run --app-id {project.Name} --app-port %APP_PORT% --dapr-grpc-port %DAPR_GRPC_PORT% --dapr-http-port %DAPR_HTTP_PORT% --metrics-port %METRICS_PORT% --placement-host-address localhost:{daprPlacementPort}",
                     };
 
                     // When running locally `-config` specifies a filename, not a configuration name. By convention


### PR DESCRIPTION
This PR:
- Is continued work on #965 
- Fixes the issues detected after merging #966 
- Fixes multiple args which are missing a `-` in their name

All affected arguments have been fixed to match the ones in `dapr run --help`

```
dapr --version
CLI version: 1.0.0
Runtime version: 1.0.1

dapr run --help
Run Dapr and (optionally) your application side by side. Supported platforms: Self-hosted

Usage:
  dapr run [flags]

Examples:

# Run a .NET application:
  dapr run --app-id myapp --app-port 5000 -- dotnet run
# Run a Java application:
  dapr run --app-id myapp -- java -jar myapp.jar
# Run a NodeJs application that listens to port 3000:
  dapr run --app-id myapp --app-port 3000 -- node myapp.js
# Run a Python application:
  dapr run --app-id myapp -- python myapp.py
# Run sidecar only:
  dapr run --app-id myapp


Flags:
  -a, --app-id string                   The id for your application, used for service discovery
      --app-max-concurrency int         The concurrency level of the application, otherwise is unlimited (default -1)
  -p, --app-port int                    The port your application is listening on (default -1)
  -P, --app-protocol string             The protocol (gRPC or HTTP) Dapr uses to talk to the application (default "http")
      --app-ssl                         Enable https when Dapr invokes the application
  -d, --components-path string          The path for components directory (default "C:\\Users\\mmisztal\\.dapr\\components")
  -c, --config string                   Dapr configuration file (default "C:\\Users\\mmisztal\\.dapr\\config.yaml")
  -G, --dapr-grpc-port int              The gRPC port for Dapr to listen on (default -1)
  -H, --dapr-http-port int              The HTTP port for Dapr to listen on (default -1)
      --enable-profiling                Enable pprof profiling via an HTTP endpoint
  -h, --help                            Print this help message
      --log-level string                The log verbosity. Valid values are: debug, info, warn, error, fatal, or panic (default "info")
  -M, --metrics-port int                The port of metrics on dapr (default -1)
      --placement-host-address string   The host on which the placement service resides (default "localhost")
      --profile-port int                The port for the profile server to listen on (default -1)
```