### PR TITLE
remove 'tye.yaml' verbiage for YAML errors (#1033)

### DIFF
--- a/src/Microsoft.Tye.Core/CoreStrings.resx
+++ b/src/Microsoft.Tye.Core/CoreStrings.resx
@@ -166,13 +166,13 @@
     <value>Services must have unique names.</value>
   </data>
   <data name="UnexpectedType" xml:space="preserve">
-    <value>Unexpected node type in tye.yaml. Expected "{expected}" but got "{actual}".</value>
+    <value>Unexpected node type in YAML file. Expected "{expected}" but got "{actual}".</value>
   </data>
   <data name="UnrecognizedKey" xml:space="preserve">
-    <value>Unexpected key "{key}" in tye.yaml.</value>
+    <value>Unexpected key "{key}" in YAML file.</value>
   </data>
   <data name="UnexpectedTypes" xml:space="preserve">
-    <value>Unexpected node type in tye.yaml. Expected one of ({expected}) but got "{actual}".</value>
+    <value>Unexpected node type in YAML file. Expected one of ({expected}) but got "{actual}".</value>
   </data>
   <data name="PathNotFound" xml:space="preserve">
     <value>Path "{path}" was not found.</value>

--- a/src/Microsoft.Tye.Core/CoreStrings.resx
+++ b/src/Microsoft.Tye.Core/CoreStrings.resx
@@ -166,13 +166,13 @@
     <value>Services must have unique names.</value>
   </data>
   <data name="UnexpectedType" xml:space="preserve">
-    <value>Unexpected node type in YAML file. Expected "{expected}" but got "{actual}".</value>
+    <value>Unexpected node type in the tye configuration file. Expected "{expected}" but got "{actual}".</value>
   </data>
   <data name="UnrecognizedKey" xml:space="preserve">
-    <value>Unexpected key "{key}" in YAML file.</value>
+    <value>Unexpected key "{key}" in the tye configuration file.</value>
   </data>
   <data name="UnexpectedTypes" xml:space="preserve">
-    <value>Unexpected node type in YAML file. Expected one of ({expected}) but got "{actual}".</value>
+    <value>Unexpected node type in the tye configuration file. Expected one of ({expected}) but got "{actual}".</value>
   </data>
   <data name="PathNotFound" xml:space="preserve">
     <value>Path "{path}" was not found.</value>

--- a/src/Microsoft.Tye.Core/Serialization/TyeYamlException.cs
+++ b/src/Microsoft.Tye.Core/Serialization/TyeYamlException.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
 using YamlDotNet.Core;
 
 namespace Tye.Serialization
@@ -20,7 +21,12 @@ namespace Tye.Serialization
         }
 
         public TyeYamlException(Mark start, string message, Exception? innerException)
-            : base($"Error parsing tye.yaml: ({start.Line}, {start.Column}): {message}", innerException)
+            : base($"Error parsing YAML: ({start.Line}, {start.Column}): {message}", innerException)
+        {
+        }
+
+        public TyeYamlException(Mark start, string message, Exception? innerException, FileInfo fileInfo)
+            : base($"Error parsing '{fileInfo.Name}': ({start.Line}, {start.Column}): {message}", innerException)
         {
         }
 

--- a/src/Microsoft.Tye.Core/Serialization/YamlParser.cs
+++ b/src/Microsoft.Tye.Core/Serialization/YamlParser.cs
@@ -42,7 +42,12 @@ namespace Tye.Serialization
             }
             catch (YamlException ex)
             {
-                throw new TyeYamlException(ex.Start, "Unable to parse tye.yaml. See inner exception.", ex);
+                if (_fileInfo != null)
+                {
+                    throw new TyeYamlException(ex.Start, $"Unable to parse '{_fileInfo.Name}'. See inner exception.", ex, _fileInfo);
+                }
+
+                throw new TyeYamlException(ex.Start, $"Unable to parse YAML.  See inner exception.", ex);
             }
 
             var app = new ConfigApplication();
@@ -50,7 +55,7 @@ namespace Tye.Serialization
             // TODO assuming first document.
             var document = _yamlStream.Documents[0];
             var node = document.RootNode;
-            ThrowIfNotYamlMapping(node);
+            ThrowIfNotYamlMapping(node, _fileInfo);
 
             app.Source = _fileInfo!;
 
@@ -106,10 +111,15 @@ namespace Tye.Serialization
             }
         }
 
-        public static void ThrowIfNotYamlMapping(YamlNode node)
+        public static void ThrowIfNotYamlMapping(YamlNode node, FileInfo? fileInfo = null)
         {
             if (node.NodeType != YamlNodeType.Mapping)
             {
+                if (fileInfo!= null)
+                {
+                    throw new TyeYamlException(node.Start,
+                        CoreStrings.FormatUnexpectedType(YamlNodeType.Mapping.ToString(), node.NodeType.ToString()), null, fileInfo);
+                }
                 throw new TyeYamlException(node.Start,
                     CoreStrings.FormatUnexpectedType(YamlNodeType.Mapping.ToString(), node.NodeType.ToString()));
             }

--- a/src/Microsoft.Tye.Core/Serialization/YamlParser.cs
+++ b/src/Microsoft.Tye.Core/Serialization/YamlParser.cs
@@ -115,7 +115,7 @@ namespace Tye.Serialization
         {
             if (node.NodeType != YamlNodeType.Mapping)
             {
-                if (fileInfo!= null)
+                if (fileInfo != null)
                 {
                     throw new TyeYamlException(node.Start,
                         CoreStrings.FormatUnexpectedType(YamlNodeType.Mapping.ToString(), node.NodeType.ToString()), null, fileInfo);

--- a/test/UnitTests/TyeDeserializationValidationTests.cs
+++ b/test/UnitTests/TyeDeserializationValidationTests.cs
@@ -290,7 +290,7 @@ flimflam";
             }
             catch (TyeYamlException e)
             {
-                Assert.StartsWith("Error parsing 'foobar.yml': (2, 1): Unexpected node type in YAML file.", e.Message);
+                Assert.StartsWith("Error parsing 'foobar.yml': (2, 1): Unexpected node type in the tye configuration file.", e.Message);
             }
         }
 

--- a/test/UnitTests/TyeDeserializationValidationTests.cs
+++ b/test/UnitTests/TyeDeserializationValidationTests.cs
@@ -1,4 +1,6 @@
-﻿using Tye;
+﻿using System;
+using System.IO;
+using Tye;
 using Tye.Serialization;
 using Xunit;
 
@@ -272,6 +274,24 @@ services:
             var app = parser.ParseConfigApplication();
             var exception = Assert.Throws<TyeYamlException>(() => app.Validate());
             Assert.Contains(errorMessage, exception.Message);
+        }
+
+        [Fact]
+        public void BadYmlFileWithArgs_ThrowsExceptionWithUsefulFilePath()
+        {
+            var input = @"
+flimflam";
+
+            using var parser = new YamlParser(input, new FileInfo("foobar.yml"));
+            try
+            {
+                parser.ParseConfigApplication();
+                Assert.False(true, "YML parsing exception expected with supplied input");
+            }
+            catch (TyeYamlException e)
+            {
+                Assert.StartsWith("Error parsing 'foobar.yml': (2, 1): Unexpected node type in YAML file.", e.Message);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
leverage file info when available, otherwise use more generic 'YAML file' phrasing