### PR TITLE
Bunch of bug fixes for dapr support and fixing cancellation on stop async

### DIFF
--- a/samples/dapr/pub-sub/orders/Startup.cs
+++ b/samples/dapr/pub-sub/orders/Startup.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -51,7 +51,17 @@ namespace orders
 
             app.UseAuthorization();
 
+            app.Use(async (context, next) =>
+            {
+                await next();
+            });
+
             app.UseCloudEvents();
+
+            app.Use(async (context, next) =>
+            {
+                await next();
+            });
 
             app.UseEndpoints(endpoints =>
             {

--- a/samples/dapr/pub-sub/orders/Startup.cs
+++ b/samples/dapr/pub-sub/orders/Startup.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -51,17 +50,7 @@ namespace orders
 
             app.UseAuthorization();
 
-            app.Use(async (context, next) =>
-            {
-                await next();
-            });
-
             app.UseCloudEvents();
-
-            app.Use(async (context, next) =>
-            {
-                await next();
-            });
 
             app.UseEndpoints(endpoints =>
             {

--- a/samples/dapr/pub-sub/orders/orders.csproj
+++ b/samples/dapr/pub-sub/orders/orders.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.0.0-rc02" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/dapr/pub-sub/products/products.csproj
+++ b/samples/dapr/pub-sub/products/products.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.0.0-rc02" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/dapr/pub-sub/store/store.csproj
+++ b/samples/dapr/pub-sub/store/store.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.0.0-rc02" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.0.0" />
   </ItemGroup>
   
 </Project>

--- a/samples/dapr/service-invocation/SentenceApp/SentenceApp.csproj
+++ b/samples/dapr/service-invocation/SentenceApp/SentenceApp.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.0.0-rc02" />
-    <PackageReference Include="Dapr.Client" Version="1.0.0-rc02" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.0.0" />
+    <PackageReference Include="Dapr.Client" Version="1.0.0" />
     <PackageReference Include="Microsoft.Tye.Extensions.Configuration" Version="0.5.0-alpha.20555.1" />
   </ItemGroup>
 

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Tye.Extensions.Dapr
 
                         // These environment variables are replaced with environment variables
                         // defined for this service.
-                        Args = $"run --app-id {project.Name} --app-port %APP_PORT% --dapr-grpc-port %DAPR_GRPC_PORT% --dapr-http-port %DAPR_HTTP_PORT% --metrics-port %METRICS_PORT% --placement-host-address localhost:{daprPlacementPort}",
+                        Args = $"run -app-id {project.Name} -app-port %APP_PORT% -dapr-grpc-port %DAPR_GRPC_PORT% --dapr-http-port %DAPR_HTTP_PORT% --metrics-port %METRICS_PORT% --placement-host-address localhost:{daprPlacementPort}",
                     };
 
                     // When running locally `-config` specifies a filename, not a configuration name. By convention
@@ -117,7 +117,7 @@ namespace Microsoft.Tye.Extensions.Dapr
                         var configFile = Path.Combine(context.Application.Source.DirectoryName!, "components", $"{daprConfig}.yaml");
                         if (File.Exists(configFile))
                         {
-                            proxy.Args += $" --config \"{configFile}\"";
+                            proxy.Args += $" -config \"{configFile}\"";
                         }
                         else
                         {
@@ -127,12 +127,12 @@ namespace Microsoft.Tye.Extensions.Dapr
 
                     if (config.Data.TryGetValue("log-level", out obj) && obj?.ToString() is string logLevel)
                     {
-                        proxy.Args += $" --log-level {logLevel}";
+                        proxy.Args += $" -log-level {logLevel}";
                     }
 
                     if (config.Data.TryGetValue("components-path", out obj) && obj?.ToString() is string componentsPath)
                     {
-                        proxy.Args += $" --components-path {componentsPath}";
+                        proxy.Args += $" -components-path {componentsPath}";
                     }
                     // Add dapr proxy as a service available to everyone.
                     proxy.Dependencies.UnionWith(context.Application.Services.Select(s => s.Name));

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Tye.Extensions.Dapr
 
                         // These environment variables are replaced with environment variables
                         // defined for this service.
-                        Args = $"run -app-id {project.Name} -app-port %APP_PORT% -dapr-grpc-port %DAPR_GRPC_PORT% --dapr-http-port %DAPR_HTTP_PORT% --metrics-port %METRICS_PORT% --placement-host-address localhost:{daprPlacementPort}",
+                        Args = $"-app-id {project.Name} -app-port %APP_PORT% -dapr-grpc-port %DAPR_GRPC_PORT% --dapr-http-port %DAPR_HTTP_PORT% --metrics-port %METRICS_PORT% --placement-host-address localhost:{daprPlacementPort}",
                     };
 
                     // When running locally `-config` specifies a filename, not a configuration name. By convention
@@ -271,7 +271,7 @@ namespace Microsoft.Tye.Extensions.Dapr
             // Starting with dapr version 11, dapr is installed in user profile/home.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var windowsPath = Environment.ExpandEnvironmentVariables("%HOMEDRIVE%/dapr/dapr.exe");
+                var windowsPath = Environment.ExpandEnvironmentVariables("%USERPROFILE%/.dapr/bin/daprd.exe");
                 if (File.Exists(windowsPath))
                 {
                     return windowsPath;
@@ -279,7 +279,7 @@ namespace Microsoft.Tye.Extensions.Dapr
             }
             else
             {
-                var nixpath = "/usr/local/bin/dapr";
+                var nixpath = Environment.ExpandEnvironmentVariables("%HOME%/.dapr/bin/daprd");
                 if (File.Exists(nixpath))
                 {
                     return nixpath;
@@ -287,7 +287,7 @@ namespace Microsoft.Tye.Extensions.Dapr
             }
 
             // Older version of dapr don't have dapr in the bin directory, but it is usually on the path.
-            return "dapr";
+            return "daprd";
         }
     }
 }

--- a/src/Microsoft.Tye.Hosting/TyeHost.cs
+++ b/src/Microsoft.Tye.Hosting/TyeHost.cs
@@ -343,9 +343,9 @@ namespace Microsoft.Tye.Hosting
                     {
                         await DashboardWebApplication.StopAsync();
                     }
-                    catch (Exception)
+                    catch (OperationCanceledException)
                     {
-                        // ignore failures from stop async
+                        // ignore cancellation failures from stop async
                     }
                 }
             }

--- a/src/Microsoft.Tye.Hosting/TyeHost.cs
+++ b/src/Microsoft.Tye.Hosting/TyeHost.cs
@@ -339,7 +339,14 @@ namespace Microsoft.Tye.Hosting
                 if (DashboardWebApplication != null)
                 {
                     // Stop the host after everything else has been shutdown
-                    await DashboardWebApplication.StopAsync();
+                    try
+                    {
+                        await DashboardWebApplication.StopAsync();
+                    }
+                    catch (Exception)
+                    {
+                        // ignore failures from stop async
+                    }
                 }
             }
 


### PR DESCRIPTION
General bug fixes I found when cleaning up tye for dapr samples and a cancellation on shutdown.

Fixes https://github.com/dotnet/tye/issues/1000 until `dapr run` is fixed to support placement port.