### PR TITLE
Specify ingress IP in Debug

### DIFF
--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -514,6 +514,11 @@ The port of the binding.
 
 The protocol (`http` or `https`).
 
+#### `ip` (`string`)
+
+The optional IP adress to bind to. Can be '*' for all addresses.
+Default is localhost.
+
 ## IngressRule
 
 `IngressRule` elements appear in an array within the `rules` property of the `Ingress` element. Rules configure the routing behavior of the ingress proxy.

--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -455,6 +455,7 @@ namespace Microsoft.Tye
                             Name = configBinding.Name,
                             Port = configBinding.Port,
                             Protocol = configBinding.Protocol ?? "http",
+                            IPAddress = configBinding.IPAddress,
                         };
                         ingress.Bindings.Add(binding);
                     }

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigIngressBinding.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigIngressBinding.cs
@@ -9,5 +9,6 @@ namespace Microsoft.Tye.ConfigModel
         public string? Name { get; set; }
         public int? Port { get; set; }
         public string? Protocol { get; set; } // HTTP or HTTPS
+        public string? IPAddress { get; set; } // Can be * or any address to listen on
     }
 }

--- a/src/Microsoft.Tye.Core/CoreStrings.resx
+++ b/src/Microsoft.Tye.Core/CoreStrings.resx
@@ -153,6 +153,9 @@
   <data name="MustBeAnInteger" xml:space="preserve">
     <value>"{value}" value must be an integer.</value>
   </data>
+  <data name="MustBeAnIPAddress" xml:space="preserve">
+    <value>"{value}" value must be an IP address, * or localhost.</value>
+  </data>
   <data name="MustBePositive" xml:space="preserve">
     <value>"{value}" value cannot be negative.</value>
   </data>

--- a/src/Microsoft.Tye.Core/IngressBindingBuilder.cs
+++ b/src/Microsoft.Tye.Core/IngressBindingBuilder.cs
@@ -9,5 +9,6 @@ namespace Microsoft.Tye
         public string? Name { get; set; }
         public int? Port { get; set; }
         public string? Protocol { get; set; } // HTTP or HTTPS
+        public string? IPAddress { get; set; }
     }
 }

--- a/src/Microsoft.Tye.Core/Serialization/ConfigIngressParser.cs
+++ b/src/Microsoft.Tye.Core/Serialization/ConfigIngressParser.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+using System.Net;
 using Microsoft.Tye.ConfigModel;
 using YamlDotNet.RepresentationModel;
 
@@ -143,6 +145,17 @@ namespace Tye.Serialization
                         }
 
                         binding.Port = port;
+                        break;
+                    case "ip":
+                        if (YamlParser.GetScalarValue(key, child.Value) is string ipString
+                            && (IPAddress.TryParse(ipString, out var ip) || ipString == "*" || ipString.Equals("localhost", StringComparison.OrdinalIgnoreCase) ))
+                        {
+                            binding.IPAddress = ip == IPAddress.Loopback || ip == IPAddress.IPv6Loopback ? null : ipString;
+                        }
+                        else
+                        {
+                            throw new TyeYamlException(child.Value.Start, CoreStrings.FormatMustBeAnIPAddress(key));
+                        }
                         break;
                     case "protocol":
                         binding.Protocol = YamlParser.GetScalarValue(key, child.Value);

--- a/src/Microsoft.Tye.Hosting/HttpProxyService.cs
+++ b/src/Microsoft.Tye.Hosting/HttpProxyService.cs
@@ -76,7 +76,8 @@ namespace Microsoft.Tye.Hosting
 
                                     var port = binding.ReplicaPorts[i];
                                     ports.Add(port);
-                                    var url = $"{binding.Protocol}://localhost:{port}";
+
+                                    var url = $"{binding.Protocol}://{binding.IPAddress ?? "localhost"}:{port}";
                                     urls.Add(url);
                                 }
 

--- a/src/Microsoft.Tye.Hosting/Model/ServiceBinding.cs
+++ b/src/Microsoft.Tye.Hosting/Model/ServiceBinding.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Net;
 
 namespace Microsoft.Tye.Hosting.Model
 {
@@ -13,6 +14,7 @@ namespace Microsoft.Tye.Hosting.Model
         public int? Port { get; set; }
         public int? ContainerPort { get; set; }
         public string? Host { get; set; }
+        public string? IPAddress { get; set; }
         public string? Protocol { get; set; }
         public List<int> ReplicaPorts { get; } = new List<int>();
     }

--- a/src/tye/ApplicationBuilderExtensions.cs
+++ b/src/tye/ApplicationBuilderExtensions.cs
@@ -207,6 +207,7 @@ namespace Microsoft.Tye
                         Name = binding.Name,
                         Port = binding.Port,
                         Protocol = binding.Protocol,
+                        IPAddress = binding.IPAddress,
                     });
                 }
 

--- a/test/E2ETest/Microsoft.Tye.E2ETests.csproj
+++ b/test/E2ETest/Microsoft.Tye.E2ETests.csproj
@@ -30,7 +30,6 @@
   <ItemGroup>
     <Content Include="testassets\**\*" CopyToOutputDirectory="PreserveNewest" />
     <Compile Remove="testassets\**\*" />
-    <None Remove="testassets\generate\apps-with-ingress.1.18.yaml" />
     <Compile Include="..\..\src\shared\KubectlDetector.cs" Link="KubectlDetector.cs" />
   </ItemGroup>
 

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -9,6 +9,8 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -764,6 +766,101 @@ services:
 
                 var htmlResponse = await client.SendAsync(htmlRequest);
                 htmlResponse.EnsureSuccessStatusCode();
+            });
+        }
+
+        [Fact]
+        public async Task IngressSpecificIPTest()
+        {
+            var allIps = GetLiveIPAddresses().ToList();
+            var testIp = allIps[new Random().Next(allIps.Count)];
+            await TestIngressIP($"'{testIp}'", new[] { testIp }, allIps.Where(ip => ip != testIp).Take(1));
+        }
+
+
+        [Fact]
+        public async Task IngressAllIPv6Test()
+        {
+            var ipV6 = GetLiveIPAddresses(AddressFamily.InterNetworkV6).FirstOrDefault();
+            if (ipV6 == null) return;
+            await TestIngressIP($"'{IPAddress.IPv6Any}'", ipV6);
+        }
+
+        [Fact]
+        public async Task IngressAllIPv4Test()
+        {
+            var ipV4 = GetLiveIPAddresses(AddressFamily.InterNetwork).FirstOrDefault();
+            if (ipV4 == null) return;
+            var ipV6 = GetLiveIPAddresses(AddressFamily.InterNetworkV6).FirstOrDefault();
+            var failIp = ipV6 == null ? Enumerable.Empty<IPAddress>() : new[] { ipV6 };
+            await TestIngressIP($"'{IPAddress.Any}'", new[] { ipV4 }, failIp);
+        }
+
+        [Fact]
+        public async Task IngressAllIPTest()
+        {
+            await TestIngressIP($"'*'", GetLiveIPAddresses().FirstOrDefault());
+        }
+
+
+        private static IEnumerable<IPAddress> GetLiveIPAddresses(AddressFamily? family = null)
+        {
+            return from ni in NetworkInterface.GetAllNetworkInterfaces()
+                   where ni.OperationalStatus == OperationalStatus.Up
+                   let prop = ni.GetIPProperties()
+                   from unicast in prop.UnicastAddresses
+                   let addr = unicast.Address
+                   where addr != IPAddress.IPv6Loopback && (family == null || addr.AddressFamily == family)
+                   select addr;
+        }
+
+        private Task TestIngressIP(string ipSetting, params IPAddress[] mustAnswer) => TestIngressIP(ipSetting, mustAnswer, Enumerable.Empty<IPAddress>());
+        private async Task TestIngressIP(string ipSetting, IEnumerable<IPAddress> mustAnswer, IEnumerable<IPAddress> mustFail)
+        {
+#if !DEBUG
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return; //disables running this test on windows as it stucks the test runner on the firewall open prompt
+#endif
+            if (!mustAnswer.Any() && !mustFail.Any())
+                return; // no IP to test against
+
+            using var projectDirectory = CopyTestProjectDirectory("apps-with-ingress");
+            var projectFile = new FileInfo(Path.Combine(projectDirectory.DirectoryPath, "tye-ip_test.yaml"));
+            File.WriteAllText(projectFile.FullName, File.ReadAllText(projectFile.FullName).Replace("__TEST_IP_STRING__", ipSetting));
+            var outputContext = new OutputContext(_sink, Verbosity.Debug);
+            var application = await ApplicationFactory.CreateAsync(outputContext, projectFile);
+
+            var handler = new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = (a, b, c, d) => true,
+                AllowAutoRedirect = true
+            };
+
+            var client = new HttpClient(new RetryHandler(handler));
+
+            await RunHostingApplication(application, new HostOptions(), async (app, uri) =>
+            {
+                foreach (var ip in mustAnswer.Concat(mustFail))
+                {
+                    try
+                    {
+                        var ingressUri = await GetServiceUrl(client, uri, "ingress");
+                        var reqUri = new UriBuilder(ingressUri + "/index.html")
+                        {
+                            Host = ip.ToString()
+                        };
+
+                        var htmlRequest = new HttpRequestMessage(HttpMethod.Get, reqUri.Uri);
+                        htmlRequest.Headers.Host = "ui.example.com";
+
+                        var htmlResponse = await client.SendAsync(htmlRequest);
+                        htmlResponse.EnsureSuccessStatusCode();
+                    }
+                    catch (Exception) when (mustFail.Contains(ip))
+                    {
+                        // this is an expected failure
+                    }
+                }
             });
         }
 

--- a/test/E2ETest/testassets/projects/apps-with-ingress/tye-ip_test.yaml
+++ b/test/E2ETest/testassets/projects/apps-with-ingress/tye-ip_test.yaml
@@ -1,0 +1,20 @@
+# tye application configuration file
+# read all about it at https://github.com/dotnet/tye
+#
+# when you've given us a try, we'd love to know what you think:
+#    https://aka.ms/AA7q20u
+#
+name: apps-with-ingress-allip-ui
+ingress:
+  - name: ingress
+    bindings:
+      - port: 8080
+        ip: __TEST_IP_STRING__
+    rules:
+      - host: ui.example.com
+        service: appC-ui
+
+services:
+  - name: appC-ui
+    project: ApplicationC-UI/ApplicationC-UI.csproj
+    replicas: 2


### PR DESCRIPTION
This allows the possibility to expose an ingress to multiple IP while running with tye run.
It might interest anybody running a service locally for the benefit of an emulator or device.
Current version only allows to expose localhost.

Ingresses bindings have a new option: ip. Setting an ip will allow binding to the ip. '*' will allow binding to all ips.
Syntax is the same as Kestrel as it is passed to Kestrel after parsing checks.

Note: unit test don't run in the windows pipeline because of firewall issues, they do run in linux and on windows, in Debug.