### PR TITLE
DockerRunner: podman workaround: create volume host dir when it doesn't exist.

### DIFF
--- a/src/Microsoft.Tye.Core/ContainerEngine.cs
+++ b/src/Microsoft.Tye.Core/ContainerEngine.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Tye
 
         public string AspNetUrlsHost => _aspnetUrlsHost;
         public string? ContainerHost => _containerHost;
+        public bool IsPodman => _isPodman;
 
         public Task<int> ExecuteAsync(
             string args,

--- a/src/Microsoft.Tye.Hosting/DockerRunner.cs
+++ b/src/Microsoft.Tye.Hosting/DockerRunner.cs
@@ -280,6 +280,15 @@ namespace Microsoft.Tye.Hosting
                     if (volumeMapping.Source != null)
                     {
                         var sourcePath = Path.GetFullPath(Path.Combine(application.ContextDirectory, volumeMapping.Source));
+                        if (application.ContainerEngine.IsPodman)
+                        {
+                            // unlike docker, podman doesn't create the host directory when it doesn't exist.
+                            // https://github.com/containers/podman/issues/10471
+                            if (!File.Exists(sourcePath) && !Directory.Exists(sourcePath))
+                            {
+                                Directory.CreateDirectory(sourcePath);
+                            }
+                        }
                         volumes += $"-v \"{sourcePath}:{volumeMapping.Target}:{(volumeMapping.ReadOnly ? "ro," : "")}z\" ";
                     }
                     else if (volumeMapping.Name != null)


### PR DESCRIPTION
@jkotalik ptal.