### PR TITLE
Fixing spelling in message seen with -v Debug

### DIFF
--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -537,7 +537,7 @@ namespace Microsoft.Tye
             if (msbuildEvaluationResult.ExitCode != 0)
             {
                 output.WriteInfoLine($"Evaluating project failed with exit code {msbuildEvaluationResult.ExitCode}");
-                output.WriteDebugLine($"Ouptut: {msbuildEvaluationResult.StandardOutput}");
+                output.WriteDebugLine($"Output: {msbuildEvaluationResult.StandardOutput}");
                 output.WriteDebugLine($"Error: {msbuildEvaluationResult.StandardError}");
             }
 


### PR DESCRIPTION

```
tye.exe run -v Debug
Loading Application Details...
Restoring and evaluating projects
Evaluating project failed with exit code 1
Ouptut: C:\Users\<User>\AppData\Local\Temp\....proj
```