### PR TITLE
Add endpoint for Tye application metadata

### DIFF
--- a/src/Microsoft.Tye.Hosting/Model/Application.cs
+++ b/src/Microsoft.Tye.Hosting/Model/Application.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Tye.Hosting.Model
             ContainerEngine = containerEngine;
         }
 
-        public string ID { get; } = Guid.NewGuid().ToString();
+        public string Id { get; } = Guid.NewGuid().ToString();
 
         public string Name { get; }
 

--- a/src/Microsoft.Tye.Hosting/Model/Application.cs
+++ b/src/Microsoft.Tye.Hosting/Model/Application.cs
@@ -12,13 +12,18 @@ namespace Microsoft.Tye.Hosting.Model
 {
     public class Application
     {
-        public Application(FileInfo source, Dictionary<string, Service> services, ContainerEngine containerEngine)
+        public Application(string name, FileInfo source, Dictionary<string, Service> services, ContainerEngine containerEngine)
         {
+            Name = name;
             Source = source.FullName;
             ContextDirectory = source.DirectoryName!;
             Services = services;
             ContainerEngine = containerEngine;
         }
+
+        public string ID { get; } = Guid.NewGuid().ToString();
+
+        public string Name { get; }
 
         public string Source { get; }
 

--- a/src/Microsoft.Tye.Hosting/Model/V1/V1Application.cs
+++ b/src/Microsoft.Tye.Hosting/Model/V1/V1Application.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.Tye.Hosting.Model.V1
 {
-    public class V1Control
+    public class V1Application
     {
         public string? ID { get; set; }
 

--- a/src/Microsoft.Tye.Hosting/Model/V1/V1Application.cs
+++ b/src/Microsoft.Tye.Hosting/Model/V1/V1Application.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Tye.Hosting.Model.V1
 {
     public class V1Application
     {
-        public string? ID { get; set; }
+        public string? Id { get; set; }
 
         public string? Name { get; set; }
 

--- a/src/Microsoft.Tye.Hosting/Model/V1/V1Control.cs
+++ b/src/Microsoft.Tye.Hosting/Model/V1/V1Control.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Microsoft.Tye.Hosting/Model/V1/V1Control.cs
+++ b/src/Microsoft.Tye.Hosting/Model/V1/V1Control.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Tye.Hosting.Model.V1
+{
+    public class V1Control
+    {
+        public string? Name { get; set; }
+    }
+}

--- a/src/Microsoft.Tye.Hosting/Model/V1/V1Control.cs
+++ b/src/Microsoft.Tye.Hosting/Model/V1/V1Control.cs
@@ -6,6 +6,10 @@ namespace Microsoft.Tye.Hosting.Model.V1
 {
     public class V1Control
     {
+        public string? ID { get; set; }
+
         public string? Name { get; set; }
+
+        public string? Source { get; set; }
     }
 }

--- a/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
+++ b/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Tye.Hosting
                 context.Response.Body,
                 new V1Application
                 {
-                    ID = app.ID,
+                    Id = app.Id,
                     Name = app.Name,
                     Source = app.Source
                 },

--- a/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
+++ b/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Tye.Hosting
         public void MapRoutes(IEndpointRouteBuilder endpoints)
         {
             endpoints.MapGet("/api/v1", ServiceIndex);
-            endpoints.MapGet("/api/v1/control", ControlIndex);
+            endpoints.MapGet("/api/v1/application", ApplicationIndex);
             endpoints.MapDelete("/api/v1/control", ControlPlaneShutdown);
             endpoints.MapGet("/api/v1/services", Services);
             endpoints.MapGet("/api/v1/services/{name}", Service);
@@ -51,16 +51,17 @@ namespace Microsoft.Tye.Hosting
             context.Response.ContentType = "application/json";
             return JsonSerializer.SerializeAsync(context.Response.Body, new[]
             {
+                $"{context.Request.Scheme}://{context.Request.Host}/api/v1/application",
                 $"{context.Request.Scheme}://{context.Request.Host}/api/v1/control",
-                $"{context.Request.Scheme}://{context.Request.Host}/api/v1/services",
                 $"{context.Request.Scheme}://{context.Request.Host}/api/v1/logs/{{service}}",
                 $"{context.Request.Scheme}://{context.Request.Host}/api/v1/metrics",
                 $"{context.Request.Scheme}://{context.Request.Host}/api/v1/metrics/{{service}}",
+                $"{context.Request.Scheme}://{context.Request.Host}/api/v1/services",
             },
             _options);
         }
 
-        private Task ControlIndex(HttpContext context)
+        private Task ApplicationIndex(HttpContext context)
         {
             var app = context.RequestServices.GetRequiredService<Application>();
 
@@ -68,7 +69,7 @@ namespace Microsoft.Tye.Hosting
 
             return JsonSerializer.SerializeAsync(
                 context.Response.Body,
-                new V1Control
+                new V1Application
                 {
                     ID = app.ID,
                     Name = app.Name,

--- a/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
+++ b/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
@@ -62,13 +62,17 @@ namespace Microsoft.Tye.Hosting
 
         private Task ControlIndex(HttpContext context)
         {
+            var app = context.RequestServices.GetRequiredService<Application>();
+
             context.Response.ContentType = "application/json";
 
             return JsonSerializer.SerializeAsync(
                 context.Response.Body,
                 new V1Control
                 {
-                    Name = "<unknown>"
+                    ID = app.ID,
+                    Name = app.Name,
+                    Source = app.Source
                 },
                 _options);     
         }

--- a/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
+++ b/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Tye.Hosting
                     Name = app.Name,
                     Source = app.Source
                 },
-                _options);     
+                _options);
         }
 
         private Task ControlPlaneShutdown(HttpContext context)

--- a/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
+++ b/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Tye.Hosting
         public void MapRoutes(IEndpointRouteBuilder endpoints)
         {
             endpoints.MapGet("/api/v1", ServiceIndex);
+            endpoints.MapGet("/api/v1/control", ControlIndex);
             endpoints.MapDelete("/api/v1/control", ControlPlaneShutdown);
             endpoints.MapGet("/api/v1/services", Services);
             endpoints.MapGet("/api/v1/services/{name}", Service);
@@ -57,6 +58,19 @@ namespace Microsoft.Tye.Hosting
                 $"{context.Request.Scheme}://{context.Request.Host}/api/v1/metrics/{{service}}",
             },
             _options);
+        }
+
+        private Task ControlIndex(HttpContext context)
+        {
+            context.Response.ContentType = "application/json";
+
+            return JsonSerializer.SerializeAsync(
+                context.Response.Body,
+                new V1Control
+                {
+                    Name = "<unknown>"
+                },
+                _options);     
         }
 
         private Task ControlPlaneShutdown(HttpContext context)

--- a/src/tye/ApplicationBuilderExtensions.cs
+++ b/src/tye/ApplicationBuilderExtensions.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Tye
                 services.Add(ingress.Name, new Service(description));
             }
 
-            return new Application(application.Source, services, application.ContainerEngine) { Network = application.Network };
+            return new Application(application.Name, application.Source, services, application.ContainerEngine) { Network = application.Network };
         }
 
         public static Tye.Hosting.Model.EnvironmentVariable ToHostingEnvironmentVariable(this EnvironmentVariableBuilder builder)

--- a/test/Test.Infrastructure/TestHelpers.cs
+++ b/test/Test.Infrastructure/TestHelpers.cs
@@ -251,8 +251,8 @@ namespace Test.Infrastructure
                 var processRunner = new ProcessRunner(logger, replicaRegistry, new ProcessRunnerOptions());
                 var dockerRunner = new DockerRunner(logger, replicaRegistry);
 
-                await processRunner.StartAsync(new Application(new FileInfo(host.Application.Source), new Dictionary<string, Service>(), ContainerEngine.Default));
-                await dockerRunner.StartAsync(new Application(new FileInfo(host.Application.Source), new Dictionary<string, Service>(), ContainerEngine.Default));
+                await processRunner.StartAsync(new Application(host.Application.Name, new FileInfo(host.Application.Source), new Dictionary<string, Service>(), ContainerEngine.Default));
+                await dockerRunner.StartAsync(new Application(host.Application.Name, new FileInfo(host.Application.Source), new Dictionary<string, Service>(), ContainerEngine.Default));
             }
 
             await DoOperationAndWaitForReplicasToChangeState(host, ReplicaState.Stopped, replicas.Length, replicas.ToHashSet(), new HashSet<string>(), TimeSpan.Zero, Purge);


### PR DESCRIPTION
Adds a `GET` `api/v1/control` endpoint that returns metadata related to the Tye application as a whole (vs. service-level metadata available via other endpoints). In particular, it returns an ID unique to the instance of Tye, the configured/inferred application name, and the source of the configuration (e.g. `tye.yaml` or a project file).

This metadata is helpful for tooling such as [`vscode-tye`](https://github.com/microsoft/vscode-tye), for example, to correlate applications back to a given workspace for debugging purposes.

Resolves #806