### PR TITLE
Add dockerfile build args documentation

### DIFF
--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -162,6 +162,10 @@ Including `image` marks the service as a *container*:
 
 The Dockerfile to build from. Uses the name of the service as the name of the image. Only supported for `tye run` currently.
 
+#### `dockerFileArgs` (`string[]`)
+
+Build arguments to use when building a Docker image. This is only used when `dockerFile` is specified.
+
 #### `dockerFileContext` (string)
 
 Path to the Dockerfile Context to run docker build against. This is only used when `dockerFile` is specified as well.

--- a/src/schema/tye-schema.json
+++ b/src/schema/tye-schema.json
@@ -383,6 +383,13 @@
                     "description": "The Dockerfile to use.",
                     "type": "string"
                 },
+                "dockerFileArgs": {
+                    "description": "Build arguments to use when building the image.",
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                },
                 "dockerFileContext": {
                     "description": "The Dockerfile context to run docker build on.",
                     "type": "string"


### PR DESCRIPTION
I had to dig a little bit to find out if it was possible to pass build arguments on a `tye.yaml` file. Turns out it is possible, it was made on #521, but I didn't find any docs explaining how. I just added a new section to the `schema.md`, let me know if there's anything I can add to make it more clear.