### PR TITLE
Allow executable-based services to have Dapr sidecars

### DIFF
--- a/src/Microsoft.Tye.Core/ExecutableServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/ExecutableServiceBuilder.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Tye
 {
-    public sealed class ExecutableServiceBuilder : ServiceBuilder
+    public sealed class ExecutableServiceBuilder : LaunchedServiceBuilder
     {
         public ExecutableServiceBuilder(string name, string executable)
             : base(name)
@@ -19,10 +19,6 @@ namespace Microsoft.Tye
         public string? WorkingDirectory { get; set; }
 
         public string? Args { get; set; }
-
-        public int Replicas { get; set; } = 1;
-
-        public List<EnvironmentVariableBuilder> EnvironmentVariables { get; } = new List<EnvironmentVariableBuilder>();
 
         public ProbeBuilder? Liveness { get; set; }
 

--- a/src/Microsoft.Tye.Core/LaunchedServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/LaunchedServiceBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Microsoft.Tye.Core/LaunchedServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/LaunchedServiceBuilder.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Tye
+{
+    public abstract class LaunchedServiceBuilder : ServiceBuilder
+    {
+        public LaunchedServiceBuilder(string name)
+            : base(name)
+        {
+        }
+
+        public List<EnvironmentVariableBuilder> EnvironmentVariables { get; } = new List<EnvironmentVariableBuilder>();
+
+        public int Replicas { get; set; } = 1;
+    }
+}

--- a/src/Microsoft.Tye.Core/ProjectServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/ProjectServiceBuilder.cs
@@ -6,15 +6,13 @@ using System.Collections.Generic;
 
 namespace Microsoft.Tye
 {
-    public class ProjectServiceBuilder : ServiceBuilder
+    public class ProjectServiceBuilder : LaunchedServiceBuilder
     {
         public ProjectServiceBuilder(string name)
             : base(name)
         {
         }
         public bool IsAspNet { get; set; }
-
-        public int Replicas { get; set; } = 1;
 
         public bool Build { get; set; }
 
@@ -25,8 +23,6 @@ namespace Microsoft.Tye
 
         // Data used for building Kubernetes manifests
         public KubernetesManifestInfo? ManifestInfo { get; set; }
-
-        public List<EnvironmentVariableBuilder> EnvironmentVariables { get; } = new List<EnvironmentVariableBuilder>();
 
         // Used when running in a container locally.
         public List<VolumeBuilder> Volumes { get; } = new List<VolumeBuilder>();

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Tye.Extensions.Dapr
 
                         // These environment variables are replaced with environment variables
                         // defined for this service.
-                        Args = $"-app-id {project.Name} -app-port %APP_PORT% -dapr-grpc-port %DAPR_GRPC_PORT% --dapr-http-port %DAPR_HTTP_PORT% --metrics-port %METRICS_PORT% --placement-host-address localhost:{daprPlacementPort}",
+                        Args = $"run --app-id {project.Name} --app-port %APP_PORT% --dapr-grpc-port %DAPR_GRPC_PORT% --dapr-http-port %DAPR_HTTP_PORT% --metrics-port %METRICS_PORT% --placement-host-address localhost:{daprPlacementPort}",
                     };
 
                     // When running locally `-config` specifies a filename, not a configuration name. By convention
@@ -120,7 +120,7 @@ namespace Microsoft.Tye.Extensions.Dapr
                         var configFile = Path.Combine(context.Application.Source.DirectoryName!, "components", $"{daprConfig}.yaml");
                         if (File.Exists(configFile))
                         {
-                            proxy.Args += $" -config \"{configFile}\"";
+                            proxy.Args += $" --config \"{configFile}\"";
                         }
                         else
                         {
@@ -130,12 +130,12 @@ namespace Microsoft.Tye.Extensions.Dapr
 
                     if (config.Data.TryGetValue("log-level", out obj) && obj?.ToString() is string logLevel)
                     {
-                        proxy.Args += $" -log-level {logLevel}";
+                        proxy.Args += $" --log-level {logLevel}";
                     }
 
                     if (config.Data.TryGetValue("components-path", out obj) && obj?.ToString() is string componentsPath)
                     {
-                        proxy.Args += $" -components-path {componentsPath}";
+                        proxy.Args += $" --components-path {componentsPath}";
                     }
                     // Add dapr proxy as a service available to everyone.
                     proxy.Dependencies.UnionWith(context.Application.Services.Select(s => s.Name));
@@ -271,10 +271,10 @@ namespace Microsoft.Tye.Extensions.Dapr
 
         private string GetDaprExecutablePath()
         {
-            // Starting with dapr version 11, dapr is installed in user profile/home.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var windowsPath = Environment.ExpandEnvironmentVariables("%USERPROFILE%/.dapr/bin/daprd.exe");
+                // The Dapr Windows installation script defaults to "C:\dapr".
+                var windowsPath = Environment.ExpandEnvironmentVariables("C:/dapr/dapr.exe");
                 if (File.Exists(windowsPath))
                 {
                     return windowsPath;
@@ -282,15 +282,15 @@ namespace Microsoft.Tye.Extensions.Dapr
             }
             else
             {
-                var nixpath = Environment.ExpandEnvironmentVariables("%HOME%/.dapr/bin/daprd");
+                var nixpath = Environment.ExpandEnvironmentVariables("/usr/local/bin/dapr");
                 if (File.Exists(nixpath))
                 {
                     return nixpath;
                 }
             }
 
-            // Older version of dapr don't have dapr in the bin directory, but it is usually on the path.
-            return "daprd";
+            // Dapr is usually on the path.
+            return "dapr";
         }
     }
 }

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -77,8 +77,11 @@ namespace Microsoft.Tye.Extensions.Dapr
                 }
 
                 // For local run, enumerate all projects, and add services for each dapr proxy.
-                var projects = context.Application.Services.OfType<ProjectServiceBuilder>().ToList();
-                foreach (var project in projects)
+                var projects = context.Application.Services.OfType<ProjectServiceBuilder>().Cast<LaunchedServiceBuilder>();
+                var executables = context.Application.Services.OfType<ExecutableServiceBuilder>().Cast<LaunchedServiceBuilder>();
+                var services = projects.Concat(executables).ToList();
+
+                foreach (var project in services)
                 {
                     // Dapr requires http. If this project isn't listening to HTTP then it's not daprized.
                     var httpBinding = project.Bindings.FirstOrDefault(b => b.Protocol == "http");


### PR DESCRIPTION
Currently only project-based services will have Dapr sidecars spun up when Dapr is enabled.  This prevents use of Dapr when using non-.NET-based services with Tye (e.g. Node.js or Python).  This change allows all executable-based services (with HTTP bindings) to have Dapr sidecars.

This change also has Tye use `dapr` for starting the sidecar rather than starting the sidecar (i.e. `daprd`) directly (which plays more nicely with how Dapr expects it to be started).

Resolves #1096.