### PR TITLE
Track and report the "source" of a service.

### DIFF
--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -164,7 +164,8 @@ namespace Microsoft.Tye
 
                     if (!string.IsNullOrEmpty(configService.Project))
                     {
-                        var project = new DotnetProjectServiceBuilder(configService.Name!, new FileInfo(configService.ProjectFullPath));
+                        // TODO: Investigate possible null.
+                        var project = new DotnetProjectServiceBuilder(configService.Name!, new FileInfo(configService.ProjectFullPath!), ServiceSource.Configuration);
                         service = project;
 
                         project.Build = configService.Build ?? true;
@@ -195,7 +196,7 @@ namespace Microsoft.Tye
                     }
                     else if (!string.IsNullOrEmpty(configService.Image))
                     {
-                        var container = new ContainerServiceBuilder(configService.Name!, configService.Image!)
+                        var container = new ContainerServiceBuilder(configService.Name!, configService.Image!, ServiceSource.Configuration)
                         {
                             Args = configService.Args,
                             Replicas = configService.Replicas ?? 1
@@ -207,7 +208,7 @@ namespace Microsoft.Tye
                     }
                     else if (!string.IsNullOrEmpty(configService.DockerFile))
                     {
-                        var dockerFile = new DockerFileServiceBuilder(configService.Name!, configService.Image!)
+                        var dockerFile = new DockerFileServiceBuilder(configService.Name!, configService.Image!, ServiceSource.Configuration)
                         {
                             Args = configService.Args,
                             Build = configService.Build ?? true,
@@ -241,7 +242,7 @@ namespace Microsoft.Tye
                             workingDirectory = Path.GetDirectoryName(expandedExecutable)!;
                         }
 
-                        var executable = new ExecutableServiceBuilder(configService.Name!, expandedExecutable)
+                        var executable = new ExecutableServiceBuilder(configService.Name!, expandedExecutable, ServiceSource.Configuration)
                         {
                             Args = configService.Args,
                             WorkingDirectory = configService.WorkingDirectory != null ?
@@ -310,7 +311,8 @@ namespace Microsoft.Tye
 
                         var functionBuilder = new AzureFunctionServiceBuilder(
                             configService.Name,
-                            azureFunctionDirectory)
+                            azureFunctionDirectory,
+                            ServiceSource.Configuration)
                         {
                             Args = configService.Args,
                             Replicas = configService.Replicas ?? 1,
@@ -332,7 +334,7 @@ namespace Microsoft.Tye
                     }
                     else if (configService.External)
                     {
-                        var external = new ExternalServiceBuilder(configService.Name);
+                        var external = new ExternalServiceBuilder(configService.Name, ServiceSource.Configuration);
                         service = external;
                     }
                     else

--- a/src/Microsoft.Tye.Core/AzureFunctionServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/AzureFunctionServiceBuilder.cs
@@ -6,8 +6,8 @@ namespace Microsoft.Tye
 {
     public class AzureFunctionServiceBuilder : ServiceBuilder
     {
-        public AzureFunctionServiceBuilder(string name, string path)
-            : base(name)
+        public AzureFunctionServiceBuilder(string name, string path, ServiceSource source)
+            : base(name, source)
         {
             FunctionPath = path;
         }

--- a/src/Microsoft.Tye.Core/ContainerServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/ContainerServiceBuilder.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Tye
 {
     public sealed class ContainerServiceBuilder : ServiceBuilder
     {
-        public ContainerServiceBuilder(string name, string image)
-            : base(name)
+        public ContainerServiceBuilder(string name, string image, ServiceSource source)
+            : base(name, source)
         {
             Image = image;
         }

--- a/src/Microsoft.Tye.Core/DockerFileServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/DockerFileServiceBuilder.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Tye
 {
     public class DockerFileServiceBuilder : ProjectServiceBuilder
     {
-        public DockerFileServiceBuilder(string name, string image)
-            : base(name)
+        public DockerFileServiceBuilder(string name, string image, ServiceSource source)
+            : base(name, source)
         {
             Image = image;
         }

--- a/src/Microsoft.Tye.Core/DotnetProjectServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/DotnetProjectServiceBuilder.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Tye
 {
     public class DotnetProjectServiceBuilder : ProjectServiceBuilder
     {
-        public DotnetProjectServiceBuilder(string name, FileInfo projectFile)
-            : base(name)
+        public DotnetProjectServiceBuilder(string name, FileInfo projectFile, ServiceSource source)
+            : base(name, source)
         {
             ProjectFile = projectFile;
         }

--- a/src/Microsoft.Tye.Core/ExecutableServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/ExecutableServiceBuilder.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Tye
 {
     public sealed class ExecutableServiceBuilder : LaunchedServiceBuilder
     {
-        public ExecutableServiceBuilder(string name, string executable)
-            : base(name)
+        public ExecutableServiceBuilder(string name, string executable, ServiceSource source)
+            : base(name, source)
         {
             Executable = executable;
         }

--- a/src/Microsoft.Tye.Core/ExternalServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/ExternalServiceBuilder.cs
@@ -6,8 +6,8 @@ namespace Microsoft.Tye
 {
     public sealed class ExternalServiceBuilder : ServiceBuilder
     {
-        public ExternalServiceBuilder(string name)
-            : base(name)
+        public ExternalServiceBuilder(string name, ServiceSource source)
+            : base(name, source)
         {
         }
     }

--- a/src/Microsoft.Tye.Core/LaunchedServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/LaunchedServiceBuilder.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Tye
 {
     public abstract class LaunchedServiceBuilder : ServiceBuilder
     {
-        public LaunchedServiceBuilder(string name)
-            : base(name)
+        public LaunchedServiceBuilder(string name, ServiceSource source)
+            : base(name, source)
         {
         }
 

--- a/src/Microsoft.Tye.Core/ProjectServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/ProjectServiceBuilder.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Tye
 {
     public class ProjectServiceBuilder : LaunchedServiceBuilder
     {
-        public ProjectServiceBuilder(string name)
-            : base(name)
+        public ProjectServiceBuilder(string name, ServiceSource source)
+            : base(name, source)
         {
         }
         public bool IsAspNet { get; set; }

--- a/src/Microsoft.Tye.Core/ServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/ServiceBuilder.cs
@@ -4,9 +4,10 @@ namespace Microsoft.Tye
 {
     public abstract class ServiceBuilder
     {
-        public ServiceBuilder(string name)
+        public ServiceBuilder(string name, ServiceSource source)
         {
             Name = name;
+            Source = source;
         }
 
         public string Name { get; }
@@ -17,5 +18,7 @@ namespace Microsoft.Tye
         public List<ServiceOutput> Outputs { get; } = new List<ServiceOutput>();
 
         public HashSet<string> Dependencies { get; } = new HashSet<string>();
+
+        public ServiceSource Source { get; }
     }
 }

--- a/src/Microsoft.Tye.Core/ServiceSource.cs
+++ b/src/Microsoft.Tye.Core/ServiceSource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Microsoft.Tye.Core/ServiceSource.cs
+++ b/src/Microsoft.Tye.Core/ServiceSource.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Tye
+{
+    public enum ServiceSource
+    {
+        Unknown = 0,
+        Configuration,
+        Extension,
+        Host
+    }
+}

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Tye.Extensions.Dapr
                     }
 
                     context.Output.WriteDebugLine("Injecting Dapr placement service...");
-                    var daprPlacement = new ContainerServiceBuilder("placement", daprPlacementImage)
+                    var daprPlacement = new ContainerServiceBuilder("placement", daprPlacementImage, ServiceSource.Extension)
                     {
                         Args = "./placement",
                         Bindings = {
@@ -104,7 +104,7 @@ namespace Microsoft.Tye.Extensions.Dapr
 
                     var daprExecutablePath = GetDaprExecutablePath();
 
-                    var proxy = new ExecutableServiceBuilder($"{project.Name}-dapr", daprExecutablePath)
+                    var proxy = new ExecutableServiceBuilder($"{project.Name}-dapr", daprExecutablePath, ServiceSource.Extension)
                     {
                         WorkingDirectory = context.Application.Source.DirectoryName,
 

--- a/src/Microsoft.Tye.Extensions/Elastic/ElasticStackExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Elastic/ElasticStackExtension.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Tye.Extensions.Elastic
                 // easy to set up.
                 //
                 // See: https://elk-docker.readthedocs.io/
-                var elastic = new ContainerServiceBuilder("elastic", "sebp/elk")
+                var elastic = new ContainerServiceBuilder("elastic", "sebp/elk", ServiceSource.Extension)
                 {
                     Bindings =
                     {

--- a/src/Microsoft.Tye.Extensions/Seq/SeqExtensions.cs
+++ b/src/Microsoft.Tye.Extensions/Seq/SeqExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Tye.Extensions.Seq
             {
                 context.Output.WriteDebugLine("Injecting seq service...");
 
-                var seq = new ContainerServiceBuilder("seq", "datalust/seq")
+                var seq = new ContainerServiceBuilder("seq", "datalust/seq", ServiceSource.Extension)
                 {
                     EnvironmentVariables =
                     {

--- a/src/Microsoft.Tye.Extensions/Zipkin/ZipkinExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Zipkin/ZipkinExtension.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Tye.Extensions.Zipkin
             else
             {
                 context.Output.WriteDebugLine("Injecting zipkin service...");
-                var service = new ContainerServiceBuilder("zipkin", "openzipkin/zipkin")
+                var service = new ContainerServiceBuilder("zipkin", "openzipkin/zipkin", ServiceSource.Extension)
                 {
                     Bindings =
                     {

--- a/src/Microsoft.Tye.Hosting/DockerRunner.cs
+++ b/src/Microsoft.Tye.Hosting/DockerRunner.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Tye.Hosting
                     b.ReplicaPorts.Add(b.Port.Value);
                     proxyDescription.Bindings.Add(b);
                 }
-                var proxyContainerService = new Service(proxyDescription);
+                var proxyContainerService = new Service(proxyDescription, ServiceSource.Host);
                 containers.Add(proxyContainerService);
                 proxies.Add(proxyContainerService);
             }

--- a/src/Microsoft.Tye.Hosting/Model/Service.cs
+++ b/src/Microsoft.Tye.Hosting/Model/Service.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Tye.Hosting.Model
 {
     public class Service
     {
-        public Service(ServiceDescription description)
+        public Service(ServiceDescription description, ServiceSource source)
         {
             Description = description;
 
@@ -29,11 +29,15 @@ namespace Microsoft.Tye.Hosting.Model
             {
                 entry.Replica.State = entry.State;
             });
+
+            ServiceSource = source;
         }
 
         public ServiceDescription Description { get; }
 
         public int Restarts { get; set; }
+
+        public ServiceSource ServiceSource { get; }
 
         public ServiceType ServiceType
         {

--- a/src/Microsoft.Tye.Hosting/Model/V1/V1Service.cs
+++ b/src/Microsoft.Tye.Hosting/Model/V1/V1Service.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Tye.Hosting.Model.V1
     public class V1Service
     {
         public V1ServiceDescription? Description { get; set; }
+        public ServiceSource ServiceSource { get; set; }
         public ServiceType ServiceType { get; set; }
         public int Restarts { get; set; }
         public V1ServiceStatus? Status { get; set; }

--- a/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
+++ b/src/Microsoft.Tye.Hosting/TyeDashboardApi.cs
@@ -228,6 +228,7 @@ namespace Microsoft.Tye.Hosting
 
             var serviceJson = new V1Service()
             {
+                ServiceSource = service.ServiceSource,
                 ServiceType = service.ServiceType,
                 Status = v1Status,
                 Description = v1ServiceDescription,

--- a/src/tye/ApplicationBuilderExtensions.cs
+++ b/src/tye/ApplicationBuilderExtensions.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Tye
                     });
                 }
 
-                services.Add(service.Name, new Service(description));
+                services.Add(service.Name, new Service(description, service.Source));
             }
 
             // Ingress get turned into services for hosting
@@ -210,7 +210,7 @@ namespace Microsoft.Tye
                     });
                 }
 
-                services.Add(ingress.Name, new Service(description));
+                services.Add(ingress.Name, new Service(description, ServiceSource.Host));
             }
 
             return new Application(application.Name, application.Source, services, application.ContainerEngine) { Network = application.Network };

--- a/test/E2ETest/TyeRunTests.cs
+++ b/test/E2ETest/TyeRunTests.cs
@@ -249,7 +249,7 @@ services:
             application.Services.Remove(project);
 
             var outputFileName = project.AssemblyName + ".dll";
-            var container = new ContainerServiceBuilder(project.Name, $"mcr.microsoft.com/dotnet/core/aspnet:{project.TargetFrameworkVersion}")
+            var container = new ContainerServiceBuilder(project.Name, $"mcr.microsoft.com/dotnet/core/aspnet:{project.TargetFrameworkVersion}", ServiceSource.Configuration)
             {
                 IsAspNet = true
             };
@@ -296,7 +296,7 @@ services:
             application.Services.Remove(project);
 
             var outputFileName = project.AssemblyName + ".dll";
-            var container = new ContainerServiceBuilder(project.Name, $"mcr.microsoft.com/dotnet/core/aspnet:{project.TargetFrameworkVersion}")
+            var container = new ContainerServiceBuilder(project.Name, $"mcr.microsoft.com/dotnet/core/aspnet:{project.TargetFrameworkVersion}", ServiceSource.Configuration)
             {
                 IsAspNet = true
             };


### PR DESCRIPTION
Adds a `ServiceSource` property to service builders, which then gets propagated through the dashboard API service endpoints.

Resolves #1123.