### PR TITLE
Log the Pid after Tye application is started

### DIFF
--- a/src/Microsoft.Tye.Hosting/TyeHost.cs
+++ b/src/Microsoft.Tye.Hosting/TyeHost.cs
@@ -109,6 +109,7 @@ namespace Microsoft.Tye.Hosting
             try
             {
                 await _processor.StartAsync(_application);
+                _logger.LogInformation($"Application {_application.Name} started successfully with Pid: {Process.GetCurrentProcess().Id}");
             }
             catch (TyeBuildException ex)
             {


### PR DESCRIPTION
The tooling needs the `pid` of the application after it is started to match it to the applications the tooling has started and then execute operations on it (e.g. shutdown).

[microsoft/vscode-tye#127](https://github.com/microsoft/vscode-tye/issues/127) is such request from tooling where `pid` is required.

This PR adds a log to emit the `pid` after the application has started.