### PR TITLE
Removes Dapr placement server management

### DIFF
--- a/samples/dapr/pub-sub/tye.yaml
+++ b/samples/dapr/pub-sub/tye.yaml
@@ -8,10 +8,6 @@ name: dapr
 extensions:
 - name: dapr
 
-  # If you want to use a different tag or container port
-  # placement-image: daprio/dapr
-  # placement-container-port: 50005
-
   # log-level configures the log level of the dapr sidecar
   log-level: debug
 
@@ -24,11 +20,8 @@ extensions:
   # components-path configures the components path of the dapr sidecar
   components-path: "./components/"
 
-  # You can instruct Tye to not create the Dapr placement container on your behalf. This is required if you have Dapr running and want to use that container.
-  # Doing a `docker ps` can show if its already running. If it's running then you can set 'exclude-placement-container: true' with `placement-port: xxxx` set to the host port of that container.
-  # (i.e. In Windows + WSL2, Dapr uses 6050 as the host port)
-
-  # exclude-placement-container: true
+  # If not using the default Dapr placement service or otherwise using a placement service on a nonstandard port,
+  # you can configure the Dapr sidecar to use an explicit port.
   # placement-port: 6050
 services:
 - name: orders

--- a/samples/dapr/pub-sub/tye.yaml
+++ b/samples/dapr/pub-sub/tye.yaml
@@ -42,7 +42,7 @@ services:
 #
 # Doing a `docker ps` can show if its already running. If that's the case
 # then comment out out when running locally. 
-- name: redis
-  image: redis
-  bindings: 
-  - port: 6379
+# - name: redis
+#   image: redis
+#   bindings: 
+#   - port: 6379

--- a/samples/dapr/service-invocation/tye.yaml
+++ b/samples/dapr/service-invocation/tye.yaml
@@ -8,10 +8,6 @@ name: distributedtyedemo
 extensions:
 - name: dapr
 
-  # If you want to use a different tag or container port
-  # placement-image: daprio/dapr
-  # placement-container-port: 50005
-
   # log-level configures the log level of the dapr sidecar
   log-level: debug
 
@@ -24,11 +20,8 @@ extensions:
   # components-path configures the components path of the dapr sidecard
   # components-path: "./components/"
 
-  # You can instruct Tye to not create the Dapr placement container on your behalf. This is required if you have Dapr running and want to use that container.
-  # Doing a `docker ps` can show if its already running. If it's running then you can set 'exclude-placement-container: true' with `placement-port: xxxx` set to the host port of that container.
-  # (i.e. In Windows + WSL2, Dapr uses 6050 as the host port)
-
-  # exclude-placement-container: true
+  # If not using the default Dapr placement service or otherwise using a placement service on a nonstandard port,
+  # you can configure the Dapr sidecar to use an explicit port.
   # placement-port: 6050
 services:
 # uppercase service is a node app and is run via a dockerfile

--- a/src/Microsoft.Tye.Core/ProcessExtensions.cs
+++ b/src/Microsoft.Tye.Core/ProcessExtensions.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Tye
 {
-    internal static class ProcessExtensions
+    public static class ProcessExtensions
     {
         private static readonly bool _isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(30);
@@ -97,7 +97,7 @@ namespace Microsoft.Tye
             }
         }
 
-        private static void RunProcessAndWaitForExit(string fileName, string arguments, TimeSpan timeout, out string? stdout)
+        public static void RunProcessAndWaitForExit(string fileName, string arguments, TimeSpan timeout, out string? stdout)
         {
             var startInfo = new ProcessStartInfo
             {

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Tye.Extensions.Dapr
                         {
                             if (match.Groups["version"].Value == "n/a")
                             {
-                                throw new CommandException("Dapr has not been initialized (e.g. via `dapr init`).");                           
+                                throw new CommandException("Dapr has not been initialized (e.g. via `dapr init`).");
                             }
                             else
                             {


### PR DESCRIPTION
Gets Tye out of the business of creating Dapr placement services, as most applications can use the one provided by the standard Dapr initialization (e.g. via `dapr init`) and that's what `dapr` assumes when running sidecars unless otherwise directed.  (If no placement service was running, just spinning one up as Tye was previously doing isn't sufficient due to dependencies on a properly configured state store.) Maintains the ability to have Dapr sidecars use a different port via `placement-port`.  The Dapr extension will check whether Dapr has been initialized (e.g. via `dapr --version`) and fails if not, as a further hint to the user that something is amiss.

> NOTE: The placement service is required *only* for applications using Dapr actors. Applications using other Dapr features need not have it running.

Resolves #1175
Resolves #1177