### PR TITLE
Support Dapr "standalone" applications

### DIFF
--- a/samples/dapr/pub-sub/tye.yaml
+++ b/samples/dapr/pub-sub/tye.yaml
@@ -8,10 +8,6 @@ name: dapr
 extensions:
 - name: dapr
 
-  # If you want to use a different tag or container port
-  # placement-image: daprio/dapr
-  # placement-container-port: 50005
-
   # log-level configures the log level of the dapr sidecar
   log-level: debug
 
@@ -24,11 +20,8 @@ extensions:
   # components-path configures the components path of the dapr sidecar
   components-path: "./components/"
 
-  # You can instruct Tye to not create the Dapr placement container on your behalf. This is required if you have Dapr running and want to use that container.
-  # Doing a `docker ps` can show if its already running. If it's running then you can set 'exclude-placement-container: true' with `placement-port: xxxx` set to the host port of that container.
-  # (i.e. In Windows + WSL2, Dapr uses 6050 as the host port)
-
-  # exclude-placement-container: true
+  # If not using the default Dapr placement service or otherwise using a placement service on a nonstandard port,
+  # you can configure the Dapr sidecar to use an explicit port.
   # placement-port: 6050
 services:
 - name: orders

--- a/samples/dapr/pub-sub/tye.yaml
+++ b/samples/dapr/pub-sub/tye.yaml
@@ -42,7 +42,7 @@ services:
 #
 # Doing a `docker ps` can show if its already running. If that's the case
 # then comment out out when running locally. 
-- name: redis
-  image: redis
-  bindings: 
-  - port: 6379
+# - name: redis
+#   image: redis
+#   bindings: 
+#   - port: 6379

--- a/samples/dapr/service-invocation/tye.yaml
+++ b/samples/dapr/service-invocation/tye.yaml
@@ -8,10 +8,6 @@ name: distributedtyedemo
 extensions:
 - name: dapr
 
-  # If you want to use a different tag or container port
-  # placement-image: daprio/dapr
-  # placement-container-port: 50005
-
   # log-level configures the log level of the dapr sidecar
   log-level: debug
 
@@ -24,11 +20,8 @@ extensions:
   # components-path configures the components path of the dapr sidecard
   # components-path: "./components/"
 
-  # You can instruct Tye to not create the Dapr placement container on your behalf. This is required if you have Dapr running and want to use that container.
-  # Doing a `docker ps` can show if its already running. If it's running then you can set 'exclude-placement-container: true' with `placement-port: xxxx` set to the host port of that container.
-  # (i.e. In Windows + WSL2, Dapr uses 6050 as the host port)
-
-  # exclude-placement-container: true
+  # If not using the default Dapr placement service or otherwise using a placement service on a nonstandard port,
+  # you can configure the Dapr sidecar to use an explicit port.
   # placement-port: 6050
 services:
 # uppercase service is a node app and is run via a dockerfile

--- a/src/Microsoft.Tye.Core/ProcessExtensions.cs
+++ b/src/Microsoft.Tye.Core/ProcessExtensions.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Tye
 {
-    internal static class ProcessExtensions
+    public static class ProcessExtensions
     {
         private static readonly bool _isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(30);
@@ -97,7 +97,7 @@ namespace Microsoft.Tye
             }
         }
 
-        private static void RunProcessAndWaitForExit(string fileName, string arguments, TimeSpan timeout, out string? stdout)
+        public static void RunProcessAndWaitForExit(string fileName, string arguments, TimeSpan timeout, out string? stdout)
         {
             var startInfo = new ProcessStartInfo
             {

--- a/src/Microsoft.Tye.Core/Serialization/ConfigExtensionsParser.cs
+++ b/src/Microsoft.Tye.Core/Serialization/ConfigExtensionsParser.cs
@@ -16,13 +16,7 @@ namespace Tye.Serialization
                 switch (child.NodeType)
                 {
                     case YamlNodeType.Mapping:
-                        var extensionDictionary = new Dictionary<string, object>();
-                        foreach (var mapping in (YamlMappingNode)child)
-                        {
-                            var key = YamlParser.GetScalarValue(mapping.Key);
-                            extensionDictionary[key] = YamlParser.GetScalarValue(key, mapping.Value)!;
-                        }
-
+                        var extensionDictionary = YamlParser.GetDictionary(child);
                         extensions.Add(extensionDictionary);
                         break;
                     default:

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -13,71 +12,6 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Tye.Extensions.Dapr
 {
-    internal abstract class DaprExtensionCommonConfiguration
-    {
-        public int? PlacementPort  { get; set; }
-    }
-
-    internal sealed class DaprExtensionServiceConfiguration : DaprExtensionCommonConfiguration
-    {
-        public bool? Enabled { get; set; }
-    }
-
-    internal sealed class DaprExtensionConfiguration : DaprExtensionCommonConfiguration
-    {
-        public IReadOnlyDictionary<string, DaprExtensionServiceConfiguration> Services { get; set; }
-            = new Dictionary<string, DaprExtensionServiceConfiguration>();
-    }
-
-    internal static class DaprExtensionConfigurationReader
-    {
-        public static DaprExtensionConfiguration ReadConfiguration(IDictionary<string, object> rawConfiguration)
-        {
-            var configuration = new DaprExtensionConfiguration();
-
-            ReadCommonConfiguration(rawConfiguration, configuration);
-
-            if (rawConfiguration.TryGetValue("services", out var servicesObject) && servicesObject is Dictionary<string, object> rawServicesConfiguration)
-            {
-                var services = new Dictionary<string, DaprExtensionServiceConfiguration>();
-
-                foreach (var kvp in rawServicesConfiguration)
-                {
-                    if (kvp.Value is Dictionary<string, object> rawServiceConfiguration)
-                    {
-                        var serviceConfiguration = new DaprExtensionServiceConfiguration();
-
-                        ReadServiceConfiguration(rawServiceConfiguration, serviceConfiguration);
-
-                        services.Add(kvp.Key, serviceConfiguration);                        
-                    }
-                }
-
-                configuration.Services = services;
-            }
-
-            return configuration;
-        }
-
-        private static void ReadServiceConfiguration(IDictionary<string, object> rawConfiguration, DaprExtensionServiceConfiguration serviceConfiguration)
-        {
-            ReadCommonConfiguration(rawConfiguration, serviceConfiguration);
-
-            if (rawConfiguration.TryGetValue("enabled", out var obj) && obj is string && Boolean.TryParse(obj.ToString(), out var enabled))
-            {
-                serviceConfiguration.Enabled = enabled;
-            }
-        }
-
-        private static void ReadCommonConfiguration(IDictionary<string, object> rawConfiguration, DaprExtensionCommonConfiguration commonConfiguration)
-        {
-            if (rawConfiguration.TryGetValue("placement-port", out var obj) && obj?.ToString() is string && int.TryParse(obj.ToString(), out var customPlacementPort))
-            {
-                commonConfiguration.PlacementPort = customPlacementPort;
-            }
-        }
-    }
-
     internal sealed class DaprExtension : Extension
     {
         public override async Task ProcessAsync(ExtensionContext context, ExtensionConfiguration config)

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Tye.Extensions.Dapr
                         {
                             if (match.Groups["version"].Value == "n/a")
                             {
-                                throw new CommandException("Dapr has not been initialized (e.g. via `dapr init`).");                           
+                                throw new CommandException("Dapr has not been initialized (e.g. via `dapr init`).");
                             }
                             else
                             {

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtensionConfiguration.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtensionConfiguration.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Tye.Extensions.Dapr
+{
+    internal abstract class DaprExtensionCommonConfiguration
+    {
+        public int? PlacementPort  { get; set; }
+    }
+
+    internal sealed class DaprExtensionServiceConfiguration : DaprExtensionCommonConfiguration
+    {
+        public bool? Enabled { get; set; }
+    }
+
+    internal sealed class DaprExtensionConfiguration : DaprExtensionCommonConfiguration
+    {
+        public IReadOnlyDictionary<string, DaprExtensionServiceConfiguration> Services { get; set; }
+            = new Dictionary<string, DaprExtensionServiceConfiguration>();
+    }
+}

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtensionConfigurationReader.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtensionConfigurationReader.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Tye.Extensions.Dapr
+{
+    internal static class DaprExtensionConfigurationReader
+    {
+        public static DaprExtensionConfiguration ReadConfiguration(IDictionary<string, object> rawConfiguration)
+        {
+            var configuration = new DaprExtensionConfiguration();
+
+            ReadCommonConfiguration(rawConfiguration, configuration);
+
+            if (rawConfiguration.TryGetValue("services", out var servicesObject) && servicesObject is Dictionary<string, object> rawServicesConfiguration)
+            {
+                var services = new Dictionary<string, DaprExtensionServiceConfiguration>();
+
+                foreach (var kvp in rawServicesConfiguration)
+                {
+                    if (kvp.Value is Dictionary<string, object> rawServiceConfiguration)
+                    {
+                        var serviceConfiguration = new DaprExtensionServiceConfiguration();
+
+                        ReadServiceConfiguration(rawServiceConfiguration, serviceConfiguration);
+
+                        services.Add(kvp.Key, serviceConfiguration);                        
+                    }
+                }
+
+                configuration.Services = services;
+            }
+
+            return configuration;
+        }
+
+        private static void ReadServiceConfiguration(IDictionary<string, object> rawConfiguration, DaprExtensionServiceConfiguration serviceConfiguration)
+        {
+            ReadCommonConfiguration(rawConfiguration, serviceConfiguration);
+
+            if (rawConfiguration.TryGetValue("enabled", out var obj) && obj is string && Boolean.TryParse(obj.ToString(), out var enabled))
+            {
+                serviceConfiguration.Enabled = enabled;
+            }
+        }
+
+        private static void ReadCommonConfiguration(IDictionary<string, object> rawConfiguration, DaprExtensionCommonConfiguration commonConfiguration)
+        {
+            if (rawConfiguration.TryGetValue("placement-port", out var obj) && obj?.ToString() is string && int.TryParse(obj.ToString(), out var customPlacementPort))
+            {
+                commonConfiguration.PlacementPort = customPlacementPort;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Tye currently assumes that all Dapr-ized services are intended to be invoked by other services (or by the Dapr runtime itself, in terms of receiving messages from subscriptions).  This implies that all Dapr-ized services have an HTTP binding (in order to be reachable by the Dapr runtime).  If a service has no HTTP bindings, no Dapr runtime will be started for that service.

However, not all services require that; some may *only* make outbound calls to other services, directly or via pub-sub (e.g. subscribe to and receive message from an alternative source, process them, then invoke another service via Dapr).  In this case, while the Dapr runtime is still needed but the application may not expose an HTTP endpoint (i.e. intended for Dapr as it has no need).  The Dapr runtime supports this scenario, by omitting the `--app-port` parameter on startup.

This change allows more nuance in the Dapr extension.  The default behavior remains that, if a service has an HTTP binding, a Dapr runtime will be started for it, using that bound port.  Otherwise, it will not.  However, the developer can now override that behavior using a new per-service configuration setting.  In addition, if a service has only a single binding, and that binding has no explicit protocol, it will be assumed to be HTTP for the purposes of Dapr-ization.

```yaml
extensions:
- name: dapr
  services:
    app2:
      enabled: true
    app3:
      enabled: false
services:
# app1 will be Dapr-ized because it has an HTTP binding
- name: app1
  bindings:
  - port: 3000
  - protocol: http
# app2 will be Dapr-ized because it was explicitly enabled (but without specifying the `--app-port`)
- name: app2
# app3 will *not* be Dapr-ized because it was explicitly disabled above
- name: app3
  bindings:
  - port: 3000
  - protocol: http
```

> This new per-service configuration section will also form the basis for other general Dapr settings to be overridden; this PR only allows the `placement-port` setting to be overridden.

Resolves #1172
Resolves #1178 