### PR TITLE
#1129 Allow SDK prerelease

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,4 +1,7 @@
 {
+  "sdk": {
+    "allowPrerelease": true
+  },
   "tools": {
     "dotnet": "6.0.100-preview.6.21355.2",
     "runtimes": {


### PR DESCRIPTION
By default, VS 2019 has the option `Use previews of the .NET Core SDK` **unchecked**. This change overrides that setting only when working with this solution, making it possible for developers to work on it using the non-preview Visual Studio 2019 v16.6 or newer.