### PR TITLE
Bump transitive dependency for Component Detection step

### DIFF
--- a/src/Microsoft.Tye.Core/Microsoft.Tye.Core.csproj
+++ b/src/Microsoft.Tye.Core/Microsoft.Tye.Core.csproj
@@ -19,6 +19,8 @@
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
+    <!-- Bumps transitive dependency for Component Detection step -->
+    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
For quite some time component detection has failed on some insecure transitive dependencies, this fails nuget publication
https://dev.azure.com/dnceng/public/_build/results?buildId=1472129&view=logs&j=0bc77094-9fcd-5c38-f6e4-27d2ae131589&t=2331deb8-a2c0-52bb-dfb1-18607764ad9e&l=8156

In the latest .net build only one remained. This aimed to fix that by forcing an updated version through direct dependency.

