### PR TITLE
Generally kill both parent and their child processes.

### DIFF
--- a/src/Microsoft.Tye.Core/ProcessExtensions.cs
+++ b/src/Microsoft.Tye.Core/ProcessExtensions.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Tye
             }
             else
             {
-                process?.Kill();
+                process?.Kill(entireProcessTree: true);
             }
         }
     }

--- a/src/Microsoft.Tye.Core/ProcessUtil.cs
+++ b/src/Microsoft.Tye.Core/ProcessUtil.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Tye
                 {
                     if (!process.CloseMainWindow())
                     {
-                        process.Kill();
+                        process.Kill(entireProcessTree: true);
                     }
                 }
 
@@ -177,7 +177,7 @@ namespace Microsoft.Tye
 
                     if (!process.HasExited)
                     {
-                        process.Kill();
+                        process.Kill(entireProcessTree: true);
                     }
                 }
             }
@@ -197,7 +197,7 @@ namespace Microsoft.Tye
             try
             {
                 using var process = Process.GetProcessById(pid);
-                process?.Kill();
+                process?.Kill(entireProcessTree: true);
             }
             catch (ArgumentException) { }
             catch (InvalidOperationException) { }


### PR DESCRIPTION
Set `entireProcessTree` to `true` when killing processes to ensure we get the `daprd` child processes as well as its parent `dapr` process when shutting down an application.

Resolves #1231
