### PR TITLE
Add support for Azure Functions v4

### DIFF
--- a/install-tye.cmd
+++ b/install-tye.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+SETLOCAL
+PowerShell -NoProfile -NoLogo -ExecutionPolicy ByPass -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = ''; try { & '%~dp0install-tye.ps1' %*; exit $LASTEXITCODE } catch { write-host $_; exit 1 }"

--- a/install-tye.ps1
+++ b/install-tye.ps1
@@ -1,0 +1,4 @@
+
+$versionPrefix = Select-Xml -Path .\eng\Versions.props -XPath "/Project/PropertyGroup/VersionPrefix" | ForEach-Object { $_.Node.InnerXml }
+
+dotnet tool install microsoft.tye -g --version "$versionPrefix-dev" --add-source ./artifacts/packages/Debug/Shipping

--- a/install-tye.sh
+++ b/install-tye.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+versionprefix=`awk -F'[<>]' '/VersionPrefix.*VersionPrefix/{print $3}' ./eng/Versions.props`
+
+dotnet tool install microsoft.tye -g --version "$versionprefix-dev" --add-source ./artifacts/packages/Debug/Shipping

--- a/remove-tye.cmd
+++ b/remove-tye.cmd
@@ -1,0 +1,2 @@
+@echo off
+dotnet tool uninstall microsoft.tye -g

--- a/remove-tye.sh
+++ b/remove-tye.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+dotnet tool uninstall microsoft.tye -g

--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -199,7 +199,10 @@ namespace Microsoft.Tye
                             ProjectFile = configService.Project
                         };
 
-                        ProjectReader.ReadAzureFunctionProjectDetails(output, functionBuilder, projectMetadata[configService.Name]);
+                        if (functionBuilder.ProjectFile != null)
+                        {
+                            ProjectReader.ReadAzureFunctionProjectDetails(output, functionBuilder, projectMetadata[configService.Name]);
+                        }
 
                         // TODO liveness?
                         service = functionBuilder;

--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -73,9 +73,30 @@ namespace Microsoft.Tye
                     root.Extensions.Add(extension);
                 }
 
+                bool IsAzureFunctionService(ConfigService service)
+                {
+                    return !string.IsNullOrEmpty(service.AzureFunction);
+                }
+
                 var services = filter?.ServicesFilter != null ?
                     config.Services.Where(filter.ServicesFilter).ToList() :
                     config.Services;
+
+                // Infer project file for Azure Function services so they will be evaluated.
+                foreach (var service in services.Where(IsAzureFunctionService))
+                {
+                    var azureFunctionDirectory = Path.Combine(config.Source.DirectoryName!, service.AzureFunction!);
+
+                    foreach (var proj in Directory.EnumerateFiles(azureFunctionDirectory))
+                    {
+                        var fileInfo = new FileInfo(proj);
+                        if (fileInfo.Extension == ".csproj" || fileInfo.Extension == ".fsproj")
+                        {
+                            service.Project = fileInfo.FullName;
+                            break;
+                        }
+                    }
+                }
 
                 var sw = Stopwatch.StartNew();
                 // Project services will be restored and evaluated before resolving all other services.
@@ -162,7 +183,28 @@ namespace Microsoft.Tye
                         continue;
                     }
 
-                    if (!string.IsNullOrEmpty(configService.Project))
+                    // NOTE: Evaluate Azure Function services before project services as both use Project.
+                    if (IsAzureFunctionService(configService))
+                    {
+                        var azureFunctionDirectory = Path.Combine(config.Source.DirectoryName!, configService.AzureFunction!);
+
+                        var functionBuilder = new AzureFunctionServiceBuilder(
+                            configService.Name,
+                            azureFunctionDirectory,
+                            ServiceSource.Configuration)
+                        {
+                            Args = configService.Args,
+                            Replicas = configService.Replicas ?? 1,
+                            FuncExecutablePath = configService.FuncExecutable,
+                            ProjectFile = configService.Project
+                        };
+
+                        ProjectReader.ReadAzureFunctionProjectDetails(output, functionBuilder, projectMetadata[configService.Name]);
+
+                        // TODO liveness?
+                        service = functionBuilder;
+                    }
+                    else if (!string.IsNullOrEmpty(configService.Project))
                     {
                         // TODO: Investigate possible null.
                         var project = new DotnetProjectServiceBuilder(configService.Name!, new FileInfo(configService.ProjectFullPath!), ServiceSource.Configuration);
@@ -304,33 +346,6 @@ namespace Microsoft.Tye
                         AddToRootServices(root, dependencies, configService.Name);
 
                         continue;
-                    }
-                    else if (!string.IsNullOrEmpty(configService.AzureFunction))
-                    {
-                        var azureFunctionDirectory = Path.Combine(config.Source.DirectoryName!, configService.AzureFunction);
-
-                        var functionBuilder = new AzureFunctionServiceBuilder(
-                            configService.Name,
-                            azureFunctionDirectory,
-                            ServiceSource.Configuration)
-                        {
-                            Args = configService.Args,
-                            Replicas = configService.Replicas ?? 1,
-                            FuncExecutablePath = configService.FuncExecutable,
-                        };
-
-                        foreach (var proj in Directory.EnumerateFiles(azureFunctionDirectory))
-                        {
-                            var fileInfo = new FileInfo(proj);
-                            if (fileInfo.Extension == ".csproj" || fileInfo.Extension == ".fsproj")
-                            {
-                                functionBuilder.ProjectFile = fileInfo.FullName;
-                                break;
-                            }
-                        }
-
-                        // TODO liveness?
-                        service = functionBuilder;
                     }
                     else if (configService.External)
                     {

--- a/src/Microsoft.Tye.Core/AzureFunctionServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/AzureFunctionServiceBuilder.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Tye
         public string FunctionPath { get; }
         public string? FuncExecutablePath { get; set; }
         public string? ProjectFile { get; set; }
+        public string? AzureFunctionsVersion { get; set; }
         public List<EnvironmentVariableBuilder> EnvironmentVariables { get; } = new List<EnvironmentVariableBuilder>();
     }
 }

--- a/src/Microsoft.Tye.Hosting/FuncFinder.cs
+++ b/src/Microsoft.Tye.Hosting/FuncFinder.cs
@@ -78,35 +78,35 @@ namespace Microsoft.Tye.Hosting
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var funcPathStandalone = Environment.ExpandEnvironmentVariables("%PROGRAMFILES%/Microsoft/Azure Functions Core Tools/func.dll");
+                var funcPathStandalone = Environment.ExpandEnvironmentVariables("%PROGRAMFILES%/Microsoft/Azure Functions Core Tools/func.exe");
                 if (File.Exists(funcPathStandalone))
                 {
                     return funcPathStandalone;
                 }
 
-                return Environment.ExpandEnvironmentVariables("%APPDATA%/npm/node_modules/azure-functions-core-tools/bin/func.dll");
+                return Environment.ExpandEnvironmentVariables("%APPDATA%/npm/node_modules/azure-functions-core-tools/bin/func.exe");
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                var funcPathStandalone = $"/usr/lib/azure-functions-core-tools-{version}/func.dll";
+                var funcPathStandalone = $"/usr/lib/azure-functions-core-tools-{version}/func";
                 if (File.Exists(funcPathStandalone))
                 {
                     return funcPathStandalone;
                 }
 
-                return "/usr/local/lib/node_modules/azure-functions-core-tools/bin/func.dll";
+                return "/usr/local/lib/node_modules/azure-functions-core-tools/bin/func";
             }
             else
             {
                 // For brew path, just find a folder that supports functions v{version}.
                 var funcDirectories = Directory.GetDirectories($"/usr/local/Cellar/azure-functions-core-tools@{version}/");
-                var funcPathStandalone = Path.Combine(funcDirectories.LastOrDefault() ?? "", "func.dll");
+                var funcPathStandalone = Path.Combine(funcDirectories.LastOrDefault() ?? "", "func");
                 if (File.Exists(funcPathStandalone))
                 {
                     return funcPathStandalone;
                 }
 
-                return "/usr/local/lib/node_modules/azure-functions-core-tools/bin/func.dll";
+                return "/usr/local/lib/node_modules/azure-functions-core-tools/bin/func";
             }
         }
 

--- a/src/Microsoft.Tye.Hosting/FuncFinder.cs
+++ b/src/Microsoft.Tye.Hosting/FuncFinder.cs
@@ -52,10 +52,10 @@ namespace Microsoft.Tye.Hosting
         private string? FindFuncForVersion(AzureFunctionRunInfo func)
         {
             int version = 4; // Default to the latest version (v4).
-            
+
             if (!string.IsNullOrWhiteSpace(func.AzureFunctionsVersion))
             {
-                var match = Regex.Match(func.AzureFunctionsVersion, @"^[vV](?<number>\d+)$");
+                var match = Regex.Match(func.AzureFunctionsVersion, @"^[vV]?(?<number>\d+)$");
 
                 if (match.Success && int.TryParse(match.Groups["number"].Value, out int parsedValue))
                 {

--- a/src/Microsoft.Tye.Hosting/Model/AzureFunctionRunInfo.cs
+++ b/src/Microsoft.Tye.Hosting/Model/AzureFunctionRunInfo.cs
@@ -11,12 +11,14 @@ namespace Microsoft.Tye.Hosting.Model
         public AzureFunctionRunInfo(AzureFunctionServiceBuilder function)
         {
             Args = function.Args;
+            AzureFunctionsVersion = function.AzureFunctionsVersion;
             FunctionPath = function.FunctionPath;
             FuncExecutablePath = function.FuncExecutablePath;
             ProjectFile = function.ProjectFile;
         }
 
         public string? Args { get; }
+        public string? AzureFunctionsVersion { get; }
         public string FunctionPath { get; }
         public string? FuncExecutablePath { get; set; }
         public string? ProjectFile { get; set; }

--- a/src/tye/ProjectEvaluation.targets
+++ b/src/tye/ProjectEvaluation.targets
@@ -34,6 +34,7 @@
       <_MicrosoftTye_ProjectMetadata Include="MicrosoftNETPlatformLibrary: $(MicrosoftNETPlatformLibrary)" />
       <_MicrosoftTye_ProjectMetadata Include="_AspNetCoreAppSharedFxIsEnabled: $(_AspNetCoreAppSharedFxIsEnabled)" />
       <_MicrosoftTye_ProjectMetadata Include="UsingMicrosoftNETSdkWeb: $(UsingMicrosoftNETSdkWeb)" />
+      <_MicrosoftTye_ProjectMetadata Include="AzureFunctionsVersion: $(AzureFunctionsVersion)" />
     </ItemGroup>
 
     <WriteLinesToFile


### PR DESCRIPTION
Updates the way in which we locate an Azure Functions runtime. Previously, this was hardcoded to version 3.  With this change, Tye will attempt to extract the `AzureFunctionsVersion` from the project file (assuming a .NET-based function), then using that to locate the proper runtime.  If no project or property was found, then Tye falls back to version 4.

Tye will now also use the host `func` executable to start the Azure Functions runtime, where previously it has executed the `func.dll` directly.  (For version 4, this method of starting the runtime no longer works.)

Resolves #1241.

> Also adds Tye installation/uninstallation scripts to eliminate having to remember/type the (often version-specific) commands.