### PR TITLE
Added missing parameter `/nologo` for `dotnet publish`

### DIFF
--- a/src/Microsoft.Tye.Core/PublishProjectStep.cs
+++ b/src/Microsoft.Tye.Core/PublishProjectStep.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Tye
 
             output.WriteDebugLine("Running 'dotnet publish'.");
             var dotnetPublishArguments = project.BuildProperties.TryGetValue("TargetFramework", out var framework)
-                ? $"publish \"{project.ProjectFile.FullName}\" -c Release -f {framework} -o \"{outputDirectory.DirectoryPath}\""
-                : $"publish \"{project.ProjectFile.FullName}\" -c Release -o \"{outputDirectory.DirectoryPath}\"";
+                ? $"publish \"{project.ProjectFile.FullName}\" -c Release -f {framework} -o \"{outputDirectory.DirectoryPath}\" /nologo"
+                : $"publish \"{project.ProjectFile.FullName}\" -c Release -o \"{outputDirectory.DirectoryPath}\" /nologo";
 
             output.WriteCommandLine("dotnet", dotnetPublishArguments);
 


### PR DESCRIPTION
Based on the current implementations `/nologo` will be used instead of `--nologo` as listed in the CLI Help.

Fix #1294 