### PR TITLE
Added ability to define namespace per service.

### DIFF
--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -148,6 +148,10 @@ The service name. Each service must have a name, and it must be a legal DNS name
 - Start with an alphanumeric character
 - End with an alphanumeric character
 
+#### `namespace` (string)
+
+Allows configuring the Kubernetes namespace for this service. If unconfigured, Tye will use the application namespace.
+
 #### `project` (string)
 
 The relative path from `tye.yaml` to a `.csproj` or `.fsproj`. 

--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -360,6 +360,9 @@ namespace Microsoft.Tye
                         throw new CommandException("Unable to determine service type.");
                     }
 
+                    // Set namespace, service scoped
+                    service.Namespace = configService.Namespace;
+
                     // Add dependencies to ourself before adding ourself to avoid self reference
                     service.Dependencies.UnionWith(dependencies);
 
@@ -470,6 +473,7 @@ namespace Microsoft.Tye
                 {
                     var ingress = new IngressBuilder(configIngress.Name!);
                     ingress.Replicas = configIngress.Replicas ?? 1;
+                    ingress.Namespace = configIngress.Namespace;
 
                     root.Ingress.Add(ingress);
 

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigIngress.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigIngress.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Tye.ConfigModel
     {
         [Required]
         public string Name { get; set; } = default!;
+        public string? Namespace { get; set; }
         public int? Replicas { get; set; }
         public List<ConfigIngressRule> Rules { get; set; } = new List<ConfigIngressRule>();
         public List<ConfigIngressBinding> Bindings { get; set; } = new List<ConfigIngressBinding>();

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigService.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigService.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Tye.ConfigModel
         [RegularExpression("[a-z]([-a-z0-9]*[a-z0-9])?", ErrorMessage = ErrorMessage)]
         [MaxLength(63, ErrorMessage = MaxLengthErrorMessage)]
         public string Name { get; set; } = default!;
+        public string? Namespace { get; set; }
         public bool External { get; set; }
         public string? Image { get; set; }
         public string? DockerFile { get; set; }

--- a/src/Microsoft.Tye.Core/IngressBuilder.cs
+++ b/src/Microsoft.Tye.Core/IngressBuilder.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Tye
 
         public string Name { get; set; }
 
+        public string? Namespace { get; set; }
+
         public int Replicas { get; set; } = 1;
 
         public List<IngressBindingBuilder> Bindings { get; set; } = new List<IngressBindingBuilder>();

--- a/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
+++ b/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
@@ -36,7 +36,12 @@ namespace Microsoft.Tye
             var metadata = new YamlMappingNode();
             root.Add("metadata", metadata);
             metadata.Add("name", ingress.Name);
-            if (!string.IsNullOrEmpty(application.Namespace))
+
+            if (!string.IsNullOrWhiteSpace(ingress.Namespace))
+            {
+                metadata.Add("namespace", ingress.Namespace);
+            }
+            else if (!string.IsNullOrEmpty(application.Namespace))
             {
                 metadata.Add("namespace", application.Namespace);
             }
@@ -163,7 +168,11 @@ namespace Microsoft.Tye
             root.Add("metadata", metadata);
             metadata.Add("name", project.Name);
 
-            if (!string.IsNullOrEmpty(application.Namespace))
+            if (!string.IsNullOrWhiteSpace(project.Namespace))
+            {
+                metadata.Add("namespace", project.Namespace);
+            }
+            else if (!string.IsNullOrEmpty(application.Namespace))
             {
                 metadata.Add("namespace", application.Namespace);
             }
@@ -248,7 +257,12 @@ namespace Microsoft.Tye
             var metadata = new YamlMappingNode();
             root.Add("metadata", metadata);
             metadata.Add("name", project.Name);
-            if (!string.IsNullOrEmpty(application.Namespace))
+
+            if (!string.IsNullOrWhiteSpace(project.Namespace))
+            {
+                metadata.Add("namespace", project.Namespace);
+            }
+            else if (!string.IsNullOrEmpty(application.Namespace))
             {
                 metadata.Add("namespace", application.Namespace);
             }

--- a/src/Microsoft.Tye.Core/Serialization/ConfigIngressParser.cs
+++ b/src/Microsoft.Tye.Core/Serialization/ConfigIngressParser.cs
@@ -34,6 +34,9 @@ namespace Tye.Serialization
                     case "name":
                         configIngress.Name = YamlParser.GetScalarValue(key, child.Value).ToLowerInvariant();
                         break;
+                    case "namespace":
+                        configIngress.Namespace = YamlParser.GetScalarValue(key, child.Value);
+                        break;
                     case "replicas":
                         if (!int.TryParse(YamlParser.GetScalarValue(key, child.Value), out var replicas))
                         {

--- a/src/Microsoft.Tye.Core/Serialization/ConfigServiceParser.cs
+++ b/src/Microsoft.Tye.Core/Serialization/ConfigServiceParser.cs
@@ -35,6 +35,9 @@ namespace Tye.Serialization
                     case "name":
                         service.Name = YamlParser.GetScalarValue(key, child.Value).ToLowerInvariant();
                         break;
+                    case "namespace":
+                        service.Namespace = YamlParser.GetScalarValue(key, child.Value);
+                        break;
                     case "external":
                         if (!bool.TryParse(YamlParser.GetScalarValue(key, child.Value), out var external))
                         {

--- a/src/Microsoft.Tye.Core/ServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/ServiceBuilder.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Tye
 
         public string Name { get; }
 
+        public string? Namespace { get; set; }
+
         public List<BindingBuilder> Bindings { get; } = new List<BindingBuilder>();
 
         // TODO: this is temporary while refactoring

--- a/src/schema/tye-schema.json
+++ b/src/schema/tye-schema.json
@@ -183,6 +183,10 @@
                     "description": "The service name. Must be unique per-application.",
                     "type": "string"
                 },
+                "namespace": {
+                    "description": "Allows configuring the Kubernetes namespace for this service. If unconfigured, Tye will use the application namespace.",
+                    "type": "string"
+                },
                 "azureFunction": {
                     "description": "The directory path to the azure function.",
                     "type": "string"
@@ -227,6 +231,10 @@
                     "description": "The service name. Must be unique per-application.",
                     "type": "string"
                 },
+                "namespace": {
+                    "description": "Allows configuring the Kubernetes namespace for this service. If unconfigured, Tye will use the application namespace.",
+                    "type": "string"
+                },
                 "executable": {
                     "description": "The file path (or file name if on the system path) of an executable.",
                     "type": "string"
@@ -269,6 +277,10 @@
                     "description": "The service name. Must be unique per-application.",
                     "type": "string"
                 },
+                "namespace": {
+                    "description": "Allows configuring the Kubernetes namespace for this service. If unconfigured, Tye will use the application namespace.",
+                    "type": "string"
+                },
                 "external": {
                     "description": "Designates as service as external. External services will not be launched and can only provide bindings.",
                     "type": "boolean",
@@ -288,6 +300,10 @@
             "properties": {
                 "name": {
                     "description": "The service name. Must be unique per-application.",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "Allows configuring the Kubernetes namespace for this service. If unconfigured, Tye will use the application namespace.",
                     "type": "string"
                 },
                 "repository":
@@ -312,6 +328,10 @@
                     "description": "The service name. Must be unique per-application.",
                     "type": "string"
                 },
+                "namespace": {
+                    "description": "Allows configuring the Kubernetes namespace for this service. If unconfigured, Tye will use the application namespace.",
+                    "type": "string"
+                },
                 "include":
                 {
                     "description": "Path to tye.yaml file which will be used in the application.",
@@ -328,6 +348,10 @@
             "properties": {
                 "name": {
                     "description": "The service name. Must be unique per-application.",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "Allows configuring the Kubernetes namespace for this service. If unconfigured, Tye will use the application namespace.",
                     "type": "string"
                 },
                 "volumes": {
@@ -374,6 +398,10 @@
             "properties": {
                 "name": {
                     "description": "The service name. Must be unique per-application.",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "Allows configuring the Kubernetes namespace for this service. If unconfigured, Tye will use the application namespace.",
                     "type": "string"
                 },
                 "volumes": {
@@ -499,6 +527,10 @@
             "properties": {
                 "name": {
                     "description": "The service name. Must be unique per-application.",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "Allows configuring the Kubernetes namespace for this service. If unconfigured, Tye will use the application namespace.",
                     "type": "string"
                 },
                 "project": {


### PR DESCRIPTION
This PR enables individual services to be deployed to separate namespaces. If the service namespace is not set, the application namespace is used.

Resolves #1217 