### PR TITLE
Set environment variable for entire service endpoint.

### DIFF
--- a/src/Microsoft.Tye.Hosting/Model/Application.cs
+++ b/src/Microsoft.Tye.Hosting/Model/Application.cs
@@ -135,6 +135,13 @@ namespace Microsoft.Tye.Hosting.Model
 
                 set($"SERVICE__{configName}__HOST", binding.Host);
                 set($"{envName}_SERVICE_HOST", binding.Host);
+
+                if (!String.IsNullOrEmpty(binding.Protocol)
+                    && !String.IsNullOrEmpty(binding.Host)
+                    && binding.Port != null)
+                {
+                    set($"{envName}_SERVICE_ENDPOINT", $"{binding.Protocol}://{binding.Host}:{binding.Port}");
+                }
             }
         }
 


### PR DESCRIPTION
Some service configurations require the entire service endpoint (i.e. protocol/host/port) but don't have a mechanism to combine existing values provided through separate environment variables.  This change adds a `<service name>_SERVICE_ENDPOINT` environment variable for each service that contains its full endpoint.