### PR TITLE
Fix Dapr extension services name not matching

### DIFF
--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtensionConfigurationReader.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtensionConfigurationReader.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Tye.Extensions.Dapr
 
             if (rawConfiguration.TryGetValue("services", out var servicesObject) && servicesObject is Dictionary<string, object> rawServicesConfiguration)
             {
-                var services = new Dictionary<string, DaprExtensionServiceConfiguration>();
+                var services = new Dictionary<string, DaprExtensionServiceConfiguration>(StringComparer.OrdinalIgnoreCase);
 
                 foreach (var kvp in rawServicesConfiguration)
                 {


### PR DESCRIPTION
Fix Dapr extension services name not matching issue,  Applications services name changed from capital letters to lower-case