### PR TITLE
Fix mongo ENV variables

### DIFF
--- a/samples/mongo-sample/tye.yaml
+++ b/samples/mongo-sample/tye.yaml
@@ -3,9 +3,9 @@ services:
 - name: mongo
   image: mongo
   env:
-    - name: ME_CONFIG_MONGODB_ADMINUSERNAME
+    - name: MONGO_INITDB_ROOT_USERNAME
       value: root
-    - name: ME_CONFIG_MONGODB_ADMINPASSWORD
+    - name: MONGO_INITDB_ROOT_PASSWORD
       value: example
   bindings:
     - port: 27017


### PR DESCRIPTION
Looks like a copy paste error.  The `mongo` image uses different env variables.