### PR TITLE
Fixed issue #677 Secrets are not created on AKS non-default namespaces

### DIFF
--- a/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
+++ b/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
@@ -79,11 +79,14 @@ namespace Microsoft.Tye
                     };
 
                     var retries = 0;
+                    var namespaceParameter = !string.IsNullOrEmpty(application.Namespace)
+                        ? $"--namespace \"{application.Namespace}\""
+                        : "";
                     while (!done && retries < 60)
                     {
                         var ingressExitCode = await ProcessUtil.ExecuteAsync(
                             "kubectl",
-                            $"get ingress {ingress.Name} -o jsonpath='{{..ip}}'",
+                            $"get ingress {ingress.Name} {namespaceParameter} -o jsonpath='{{..ip}}'",
                             Environment.CurrentDirectory,
                             complete,
                             capture.StdErr);

--- a/src/Microsoft.Tye.Core/ValidateSecretStep.cs
+++ b/src/Microsoft.Tye.Core/ValidateSecretStep.cs
@@ -56,6 +56,11 @@ namespace Microsoft.Tye
 
                 var config = KubernetesClientConfiguration.BuildDefaultConfig();
 
+                if (!string.IsNullOrEmpty(application.Namespace))
+                {
+                    config.Namespace = application.Namespace;
+                }
+
                 // If namespace is null, set it to default
                 config.Namespace ??= "default";
 


### PR DESCRIPTION
Also fixing error when successfully created ingress warned as non-created because of looking into wrong Kubernetes namespace.

Fixes https://github.com/dotnet/tye/issues/677