### PR TITLE
Allow for Special Characters in Project Names when Building During Watch

### DIFF
--- a/src/Microsoft.Tye.Core/MsBuild/ProjectInSolution.cs
+++ b/src/Microsoft.Tye.Core/MsBuild/ProjectInSolution.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Find the unique name for this project, e.g. SolutionFolder\SubSolutionFolder\Project_Name
         /// </summary>
-        internal string GetUniqueProjectName()
+        public string GetUniqueProjectName()
         {
             if (_uniqueProjectName == null)
             {

--- a/src/Microsoft.Tye.Hosting/BuildWatcher.cs
+++ b/src/Microsoft.Tye.Hosting/BuildWatcher.cs
@@ -110,13 +110,13 @@ namespace Microsoft.Tye.Hosting
             }
         }
 
-        private static string GetProjectName(SolutionFile solution, string projectFile)
+        private static string GetUniqueProjectName(SolutionFile solution, string projectFile)
         {
             foreach (var project in solution.ProjectsInOrder)
             {
                 if (project.AbsolutePath == projectFile)
                 {
-                    return project.ProjectName;
+                    return project.GetUniqueProjectName();
                 }
             }
 
@@ -205,7 +205,7 @@ namespace Microsoft.Tye.Hosting
 
                     if (solutionBatch.Any())
                     {
-                        var targets = String.Join(",", solutionBatch.Keys.Select(key => GetProjectName(solution!, key)));
+                        var targets = String.Join(",", solutionBatch.Keys.Select(key => GetUniqueProjectName(solution!, key)));
 
                         tasks.Add(
                             WithRequestCompletion(


### PR DESCRIPTION
Provide the unique project name to the `-target` flag when doing an `msbuild <solution> -target:{unique project name}`.

Not only resolves the special characters but allows for the potential path in the "unique project name" (e.g., if your project is nested in a directory).

This addresses:
#1438 

Reference:
https://docs.microsoft.com/en-us/visualstudio/msbuild/how-to-build-specific-targets-in-solutions-by-using-msbuild-exe?view=vs-2022