### PR TITLE
Fix httpprobe protocol

### DIFF
--- a/src/Microsoft.Tye.Core/Serialization/ConfigServiceParser.cs
+++ b/src/Microsoft.Tye.Core/Serialization/ConfigServiceParser.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Microsoft.Tye.ConfigModel;
 using YamlDotNet.RepresentationModel;
 
@@ -346,7 +345,7 @@ namespace Tye.Serialization
                         prober.Port = port;
                         break;
                     case "protocol":
-                        prober.Path = YamlParser.GetScalarValue("protocol", child.Value);
+                        prober.Protocol = YamlParser.GetScalarValue("protocol", child.Value);
                         break;
                     case "headers":
                         prober.Headers = new List<KeyValuePair<string, object>>();


### PR DESCRIPTION
I found this error while trying to use liveness and readiness health checks

If I try to use an Grpc service with liveness and readiness then it all breaks because it has to be https
(still doesn't work because Grpc uses HTTP/2 and I think that liveness and readiness ReplicaMonitor httpclient is using HttpVersion.Version11) :/