### PR TITLE
Update windows ci image names

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,10 +49,10 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCore-Public
-            demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
+            demands: ImageOverride -equals windows.vs2019.amd64.open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals Build.Server.Amd64.VS2019
+            demands: ImageOverride -equals windows.vs2019.amd64
         variables:
           
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,10 +49,10 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCore-Public
-            demands: ImageOverride -equals windows.vs2019.amd64.open
+            demands: ImageOverride -equals windows.vs2022.amd64.open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals windows.vs2019.amd64
+            demands: ImageOverride -equals windows.vs2022.amd64
         variables:
           
 


### PR DESCRIPTION
The currently used ones have been replaced and any PR should fail without this change.