### PR TITLE
Csteeg/feature/add startstop

### DIFF
--- a/src/Microsoft.Tye.Core/HostOptions.cs
+++ b/src/Microsoft.Tye.Core/HostOptions.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Tye
         public bool Dashboard { get; set; }
 
         public List<string> Debug { get; } = new List<string>();
+        
+        public List<string> NoStart { get; } = new List<string>();
 
         public string? DistributedTraceProvider { get; set; }
 

--- a/src/Microsoft.Tye.Hosting/Dashboard/Pages/Index.razor
+++ b/src/Microsoft.Tye.Hosting/Dashboard/Pages/Index.razor
@@ -19,6 +19,7 @@
             <th>Replicas</th>
             <th>Restarts</th>
             <th>Logs</th>
+            <th>Actions</th>
         </tr>
     </thead>
     <tbody>
@@ -92,6 +93,23 @@
                     <td>@service.Replicas.Count/@service.Description.Replicas</td>
                     <td>@service.Restarts</td>
                     <td><NavLink href="@logsPath">View</NavLink></td>
+                    <td>
+                        @if (CanStartStop(service))
+                        {
+                            if (service.Replicas.Count == 0)
+                            {
+                                <button @onclick="async () => await StartServiceAsync(service)" class="btn btn-default btn-xs">
+                                    <span class="oi oi-media-play"></span>
+                                </button>
+                            }
+                            else
+                            {
+                                <button @onclick="async () => await StopServiceAsync(service)" class="btn btn-default btn-xs">
+                                    <span class="oi oi-media-stop"></span>
+                                </button>
+                            }
+                        }
+                    </td>
                 }
             </tr>
         }
@@ -99,8 +117,13 @@
 </table>
 
 @code {
-
+    static readonly ServiceType stopables = ServiceType.Container | ServiceType.Executable | ServiceType.Project | ServiceType.Function;
     private List<IDisposable> _subscriptions = new List<IDisposable>();
+
+    bool CanStartStop(Service? service)
+    {
+        return service != null && ((stopables & service.ServiceType) == service.ServiceType);
+    }
 
     string GetUrl(ServiceBinding b)
     {
@@ -119,6 +142,31 @@
     {
         InvokeAsync(() => StateHasChanged());
     }
+
+    private async Task StartServiceAsync(Service service)
+    {
+        if (service.ServiceType == ServiceType.Container)
+        {
+            await DockerRunner.RestartContainerAsync(service);
+        }
+        else
+        {
+            await ProcessRunner.RestartService(service);
+        }
+    }
+
+    private async Task StopServiceAsync(Service service)
+    {
+        if (service.ServiceType == ServiceType.Container)
+        {
+            await DockerRunner.StopContainerAsync(service);
+        }
+        else
+        {
+            await ProcessRunner.KillProcessAsync(service);
+        }
+    }
+
 
     void IDisposable.Dispose()
     {

--- a/src/Microsoft.Tye.Hosting/DockerRunner.cs
+++ b/src/Microsoft.Tye.Hosting/DockerRunner.cs
@@ -24,11 +24,13 @@ namespace Microsoft.Tye.Hosting
         private readonly ILogger _logger;
 
         private readonly ReplicaRegistry _replicaRegistry;
+        private readonly DockerRunnerOptions _options;
 
-        public DockerRunner(ILogger logger, ReplicaRegistry replicaRegistry)
+        public DockerRunner(ILogger logger, ReplicaRegistry replicaRegistry, DockerRunnerOptions options)
         {
             _logger = logger;
             _replicaRegistry = replicaRegistry;
+            _options = options;
         }
 
         public async Task StartAsync(Application application)
@@ -537,6 +539,7 @@ namespace Microsoft.Tye.Hosting
                 return Task.WhenAll(tasks);
             }
 
+            var dockerInfo = new DockerInformation();
             async Task BuildAndRunAsync(CancellationToken cancellationToken)
             {
                 await DockerBuildAsync(cancellationToken);
@@ -544,8 +547,13 @@ namespace Microsoft.Tye.Hosting
                 await DockerRunAsync(cancellationToken);
             }
 
-            var dockerInfo = new DockerInformation();
-            dockerInfo.Task = BuildAndRunAsync(dockerInfo.StoppingTokenSource.Token);
+            dockerInfo.SetBuildAndRunTask(BuildAndRunAsync);
+
+            if (!_options.ManualStartServices &&
+                !(_options.ServicesNotToStart?.Contains(service.Description.Name, StringComparer.OrdinalIgnoreCase) ?? false))
+            {
+                dockerInfo.BuildAndRun();
+            }
 
             service.Items[typeof(DockerInformation)] = dockerInfo;
         }
@@ -587,13 +595,25 @@ namespace Microsoft.Tye.Hosting
             }
         }
 
-        private Task StopContainerAsync(Service service)
+        public static async Task RestartContainerAsync(Service service)
         {
             if (service.Items.TryGetValue(typeof(DockerInformation), out var value) && value is DockerInformation di)
             {
-                di.StoppingTokenSource.Cancel();
+                await StopContainerAsync(service);
 
-                return di.Task;
+                di.BuildAndRun();
+                service.Restarts++;
+                await di.Task;
+            }
+        }
+
+        public static Task StopContainerAsync(Service service)
+        {
+            if (service.Items.TryGetValue(typeof(DockerInformation), out var value) && value is DockerInformation di)
+            {
+                di.CancelAndResetStoppingTokenSource();
+                return di.Task ?? Task.CompletedTask;
+
             }
 
             return Task.CompletedTask;
@@ -601,8 +621,27 @@ namespace Microsoft.Tye.Hosting
 
         private class DockerInformation
         {
-            public Task Task { get; set; } = default!;
-            public CancellationTokenSource StoppingTokenSource { get; } = new CancellationTokenSource();
+            private Func<CancellationToken, Task>? _buildAndRunAsync;
+
+            public Task Task { get; private set; } = default!;
+            public CancellationTokenSource StoppingTokenSource { get; private set; } = new CancellationTokenSource();
+
+            public void SetBuildAndRunTask(Func<CancellationToken, Task> func)
+            {
+                _buildAndRunAsync = func;
+            }
+
+            public async void BuildAndRun()
+            {
+                Task = _buildAndRunAsync?.Invoke(StoppingTokenSource.Token) ?? Task.CompletedTask;
+            }
+
+            internal void CancelAndResetStoppingTokenSource()
+            {
+                StoppingTokenSource.Cancel();
+                StoppingTokenSource.Dispose();
+                StoppingTokenSource = new CancellationTokenSource();
+            }
         }
 
         private class DockerApplicationInformation

--- a/src/Microsoft.Tye.Hosting/DockerRunnerOptions.cs
+++ b/src/Microsoft.Tye.Hosting/DockerRunnerOptions.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.Tye.Hosting
+{
+    public class DockerRunnerOptions
+    {
+        public bool ManualStartServices { get; set; }
+        public string[]? ServicesNotToStart { get; set; }
+
+        public static DockerRunnerOptions FromHostOptions(HostOptions options)
+        {
+            return new DockerRunnerOptions
+            {
+                ManualStartServices  = options.NoStart?.Contains("*", StringComparer.OrdinalIgnoreCase) ?? false,
+                ServicesNotToStart = options.NoStart?.ToArray()
+            };
+        }
+    }
+}

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -179,10 +179,12 @@ namespace Microsoft.Tye.Hosting
         }
 
         private void LaunchService(Application application, Service service)
+
         {
-            var serviceDescription = service.Description;
-            var processInfo = new ProcessInfo(new Task[service.Description.Replicas]);
-            var serviceName = serviceDescription.Name;
+            var processInfo = service.Items.ContainsKey(typeof(ProcessInfo)) 
+                                ? (ProcessInfo)service.Items[typeof(ProcessInfo)]
+                                : new ProcessInfo(new Task[service.Description.Replicas]);
+            var serviceName = service.Description.Name;
 
             // Set by BuildAndRunService
             var args = service.Status.Args!;
@@ -297,7 +299,7 @@ namespace Microsoft.Tye.Hosting
                     try
                     {
                         service.Logs.OnNext($"[{replica}]:{path} {copiedArgs}");
-                        var processInfo = new ProcessSpec
+                        var processSpec = new ProcessSpec
                         {
                             Executable = path,
                             WorkingDirectory = workingDirectory,
@@ -351,8 +353,10 @@ namespace Microsoft.Tye.Hosting
                                     // Only increase backoff when not watching project as watch will wait for file changes before rebuild.
                                     backOff *= 2;
                                 }
-
-                                service.Restarts++;
+                                if (!processInfo.StoppedTokenSource.IsCancellationRequested)
+                                {
+                                    service.Restarts++;
+                                }
 
                                 service.Replicas.TryRemove(replica, out var _);
                                 service.ReplicaEvents.OnNext(new ReplicaEvent(ReplicaState.Removed, status));
@@ -375,6 +379,8 @@ namespace Microsoft.Tye.Hosting
                             }
                         };
 
+                        
+
                         if (_options.Watch && (service.Description.RunInfo is ProjectRunInfo runInfo))
                         {
                             var projectFile = runInfo.ProjectFile.FullName;
@@ -385,7 +391,7 @@ namespace Microsoft.Tye.Hosting
                             environment["DOTNET_WATCH"] = "1";
 
                             await new DotNetWatcher(_logger)
-                                .WatchAsync(processInfo, fileSetFactory, replica, status.StoppingTokenSource.Token);
+                                .WatchAsync(processSpec, fileSetFactory, replica, status.StoppingTokenSource.Token);
                         }
                         else if (_options.Watch && (service.Description.RunInfo is AzureFunctionRunInfo azureFunctionRunInfo) && !string.IsNullOrEmpty(azureFunctionRunInfo.ProjectFile))
                         {
@@ -397,11 +403,11 @@ namespace Microsoft.Tye.Hosting
                             environment["DOTNET_WATCH"] = "1";
 
                             await new DotNetWatcher(_logger)
-                                .WatchAsync(processInfo, fileSetFactory, replica, status.StoppingTokenSource.Token);
+                                .WatchAsync(processSpec, fileSetFactory, replica, status.StoppingTokenSource.Token);
                         }
                         else
                         {
-                            await ProcessUtil.RunAsync(processInfo, status.StoppingTokenSource.Token, throwOnError: false);
+                            await ProcessUtil.RunAsync(processSpec, status.StoppingTokenSource.Token, throwOnError: false);
                         }
                     }
                     catch (Exception ex)
@@ -429,50 +435,78 @@ namespace Microsoft.Tye.Hosting
                 }
             }
 
-            if (serviceDescription.Bindings.Count > 0)
+            void Start()
             {
-                // Each replica is assigned a list of internal ports, one mapped to each external
-                // port
-                for (int i = 0; i < serviceDescription.Replicas; i++)
+                if (service.Description!.Bindings.Count > 0)
                 {
-                    var ports = new List<(int, int, string?, string?)>();
-                    foreach (var binding in serviceDescription.Bindings)
+                    // Each replica is assigned a list of internal ports, one mapped to each external
+                    // port
+                    for (int i = 0; i < service.Description.Replicas; i++)
                     {
-                        if (binding.Port == null)
+                        var ports = new List<(int, int, string?, string?)>();
+                        foreach (var binding in service.Description.Bindings)
                         {
-                            continue;
+                            if (binding.Port == null)
+                            {
+                                continue;
+                            }
+
+                            ports.Add((binding.Port.Value, binding.ReplicaPorts[i], binding.Protocol, binding.Host));
                         }
 
-                        ports.Add((binding.Port.Value, binding.ReplicaPorts[i], binding.Protocol, binding.Host));
+                        processInfo!.Tasks[i] = RunApplicationAsync(ports, args);
                     }
-
-                    processInfo.Tasks[i] = RunApplicationAsync(ports, args);
                 }
+                else
+                {
+                    for (int i = 0; i < service.Description.Replicas; i++)
+                    {
+                        processInfo!.Tasks[i] = RunApplicationAsync(Enumerable.Empty<(int, int, string?, string?)>(), args);
+                    }
+                }
+            }
+
+            processInfo.Start = Start;
+            service.Items[typeof(ProcessInfo)] = processInfo;
+            if (!_options.ManualStartServices &&
+                !(_options.ServicesNotToStart?.Contains(serviceName, StringComparer.OrdinalIgnoreCase) ?? false))
+            {
+                processInfo.Start();
             }
             else
             {
-                for (int i = 0; i < service.Description.Replicas; i++)
+                for (var i=0;i<processInfo.Tasks.Length;i++)
                 {
-                    processInfo.Tasks[i] = RunApplicationAsync(Enumerable.Empty<(int, int, string?, string?)>(), args);
+                    processInfo.Tasks[i] = Task.CompletedTask;
                 }
             }
+        }
 
-            service.Items[typeof(ProcessInfo)] = processInfo;
+        public static async Task RestartService(Service service)
+        {
+            if (service.Items.TryGetValue(typeof(ProcessInfo), out var stateObj) && stateObj is ProcessInfo state)
+            {
+                await KillProcessAsync(service);
+                service.Restarts++;
+                state.Start();
+                await Task.WhenAll(state.Tasks);
+            }
+        }
+
+        public static async Task KillProcessAsync(Service service)
+        {
+            if (service.Items.TryGetValue(typeof(ProcessInfo), out var stateObj) && stateObj is ProcessInfo state)
+            {
+                // Cancel the token before stopping the process
+                state.StoppedTokenSource?.Cancel();
+
+                await Task.WhenAll(state.Tasks);
+                state.ResetStoppedTokenSource();
+            }
         }
 
         private Task KillRunningProcesses(IDictionary<string, Service> services)
         {
-            static Task KillProcessAsync(Service service)
-            {
-                if (service.Items.TryGetValue(typeof(ProcessInfo), out var stateObj) && stateObj is ProcessInfo state)
-                {
-                    // Cancel the token before stopping the process
-                    state.StoppedTokenSource.Cancel();
-
-                    return Task.WhenAll(state.Tasks);
-                }
-                return Task.CompletedTask;
-            }
 
             var index = 0;
             var tasks = new Task[services.Count];
@@ -541,7 +575,13 @@ namespace Microsoft.Tye.Hosting
 
             public Task[] Tasks { get; }
 
-            public CancellationTokenSource StoppedTokenSource { get; } = new CancellationTokenSource();
+            public CancellationTokenSource StoppedTokenSource { get; private set; } = new CancellationTokenSource();
+            public Action Start { get; internal set; }
+            internal void ResetStoppedTokenSource()
+            {
+                StoppedTokenSource.Dispose();
+                StoppedTokenSource = new CancellationTokenSource();
+            }
         }
 
         private class ProjectGroup

--- a/src/Microsoft.Tye.Hosting/ProcessRunnerOptions.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunnerOptions.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Tye.Hosting
         public string[]? ServicesToDebug { get; set; }
         public bool DebugAllServices { get; set; }
         public bool Watch { get; set; }
+        public bool ManualStartServices { get; set; }
+        public string[]? ServicesNotToStart { get; set; }
 
         public static ProcessRunnerOptions FromHostOptions(HostOptions options)
         {
@@ -23,6 +25,8 @@ namespace Microsoft.Tye.Hosting
                 DebugMode = options.Debug.Any(),
                 ServicesToDebug = options.Debug.ToArray(),
                 DebugAllServices = options.Debug?.Contains("*", StringComparer.OrdinalIgnoreCase) ?? false,
+                ManualStartServices  = options.NoStart?.Contains("*", StringComparer.OrdinalIgnoreCase) ?? false,
+                ServicesNotToStart = options.NoStart?.ToArray(),
                 Watch = options.Watch
             };
         }

--- a/src/Microsoft.Tye.Hosting/TyeHost.cs
+++ b/src/Microsoft.Tye.Hosting/TyeHost.cs
@@ -318,7 +318,7 @@ namespace Microsoft.Tye.Hosting
                 new DockerImagePuller(logger),
                 new FuncFinder(logger),
                 new ReplicaMonitor(logger),
-                new DockerRunner(logger, replicaRegistry),
+                new DockerRunner(logger, replicaRegistry, DockerRunnerOptions.FromHostOptions(options)),
                 new ProcessRunner(logger, replicaRegistry, ProcessRunnerOptions.FromHostOptions(options))
             };
 

--- a/src/tye/ApplicationBuilderExtensions.cs
+++ b/src/tye/ApplicationBuilderExtensions.cs
@@ -193,32 +193,40 @@ namespace Microsoft.Tye
             // Ingress get turned into services for hosting
             foreach (var ingress in application.Ingress)
             {
-                var rules = new List<IngressRule>();
+                services.TryGetValue(ingress.Name, out Service? service);
+                var description = service?.Description ?? new ServiceDescription(ingress.Name, new IngressRunInfo(new List<IngressRule>()));
+                if (!(description.RunInfo is IngressRunInfo runinfo))
+                {
+                    throw new InvalidOperationException($"Service '{ingress.Name}' was already added but not as an ingress service.");
+                }
+
+                description.Replicas = Math.Max(ingress.Replicas, description.Replicas);
 
                 foreach (var rule in ingress.Rules)
                 {
-                    rules.Add(new IngressRule(rule.Host, rule.Path, rule.Service!, rule.PreservePath));
+                    runinfo.Rules.Add(new IngressRule(rule.Host, rule.Path, rule.Service!, rule.PreservePath));
                 }
-
-                var runInfo = new IngressRunInfo(rules);
-
-                var description = new ServiceDescription(ingress.Name, runInfo)
-                {
-                    Replicas = ingress.Replicas,
-                };
 
                 foreach (var binding in ingress.Bindings)
                 {
-                    description.Bindings.Add(new ServiceBinding()
+                    //Match on name or all other properties to combind bindings to 1 instance so we can have http://*.80 listen to more then 1 service from different include files
+                    if (!description.Bindings.Any(b => (!string.IsNullOrEmpty(b.Name) && b.Name == binding.Name) ||
+                                                       (b.Port == binding.Port && b.Protocol == binding.Protocol && b.IPAddress == binding.IPAddress)))
                     {
-                        Name = binding.Name,
-                        Port = binding.Port,
-                        Protocol = binding.Protocol,
-                        IPAddress = binding.IPAddress,
-                    });
+                        description.Bindings.Add(new ServiceBinding()
+                        {
+                            Name = binding.Name,
+                            Port = binding.Port,
+                            Protocol = binding.Protocol,
+                            IPAddress = binding.IPAddress,
+                        });
+                    }
                 }
 
-                services.Add(ingress.Name, new Service(description, ServiceSource.Host));
+                if (service == null)
+                {
+                    services.Add(ingress.Name, new Service(description, ServiceSource.Host));
+                }
             }
 
             return new Application(application.Name, application.Source, application.DashboardPort, services, application.ContainerEngine)

--- a/src/tye/Program.RunCommand.cs
+++ b/src/tye/Program.RunCommand.cs
@@ -74,6 +74,15 @@ namespace Microsoft.Tye
                     Description = "Watches for code changes for all dotnet projects.",
                     Required = false
                 },
+                new Option("--no-start")
+                {
+                    Argument = new Argument<string[]>("service")
+                    {
+                        Arity = ArgumentArity.ZeroOrMore,
+                    },
+                    Description = "Skip automatic start for specific service(s). Specify \"*\" to skip start for all services.",
+                    Required = false
+                },
                 StandardOptions.Framework,
                 StandardOptions.Tags,
                 StandardOptions.Verbosity,
@@ -93,7 +102,7 @@ namespace Microsoft.Tye
 
                 var filter = ApplicationFactoryFilter.GetApplicationFactoryFilter(args.Tags);
 
-                var application = await ApplicationFactory.CreateAsync(output, args.Path, args.Framework, filter);
+                 var application = await ApplicationFactory.CreateAsync(output, args.Path, args.Framework, filter);
                 if (application.Services.Count == 0)
                 {
                     throw new CommandException($"No services found in \"{application.Source.Name}\"");
@@ -111,9 +120,10 @@ namespace Microsoft.Tye
                     LoggingProvider = args.Logs,
                     MetricsProvider = args.Metrics,
                     LogVerbosity = args.Verbosity,
-                    Watch = args.Watch
+                    Watch = args.Watch,
                 };
                 options.Debug.AddRange(args.Debug);
+                options.NoStart.AddRange(args.NoStart);
 
                 await application.ProcessExtensionsAsync(options, output, ExtensionContext.OperationKind.LocalRun);
 
@@ -153,6 +163,8 @@ namespace Microsoft.Tye
             public bool Dashboard { get; set; }
 
             public string[] Debug { get; set; } = Array.Empty<string>();
+            
+            public string[] NoStart { get; set; } = Array.Empty<string>();
 
             public string Dtrace { get; set; } = default!;
 


### PR DESCRIPTION
I didn't see PR #948 before, but it's kind of the same feature, so this one is also #876 

This feature is because our dev-team wanted to have the @dalibormesaric in #948
We have quite a large set up with loads of services in Tye and watching them all can be stressful for the developer's environment. So, we just want to quit the one service you're working on in Tye and use visual studio for that service.

The other scenario is that we quickly want to start just a few services to test or reproduce something without starting the complete environment. Therefore, I placed the buttons on the overview page instead of the service page, and added a command-line option to skip startup for specific projects (eg we have a Microsoft Fhir server project in there taking quite some time and resources). Now I could also say skip "*" so no project starts automatically and just spint up like the 3 services I need atm from the dashboard

This PR also works for docker containers that are running + I chose to reuse the created method to start the services by adding a reference to the method on the service object. This way we don't have to inject the processrunner anywhere. 