### PR TITLE
Hotreload feature

### DIFF
--- a/samples/frontend-backend/tye.yaml
+++ b/samples/frontend-backend/tye.yaml
@@ -6,3 +6,4 @@ services:
   project: backend/backend.csproj
 - name: frontend
   project: frontend/frontend.csproj
+  hotReload: true

--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Tye
                         {
                             project.BuildProperties.Add(buildProperty.Name, buildProperty.Value);
                         }
-
+                        project.HotReload = configService.HotReload ?? false;
                         project.Replicas = configService.Replicas ?? 1;
                         project.Liveness = configService.Liveness != null ? GetProbeBuilder(configService.Liveness) : null;
                         project.Readiness = configService.Readiness != null ? GetProbeBuilder(configService.Readiness) : null;

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigService.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigService.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Tye.ConfigModel
         public string? WorkingDirectory { get; set; }
         public string? Args { get; set; }
         public int? Replicas { get; set; }
+        public bool? HotReload { get; set; }
         public List<ConfigServiceBinding> Bindings { get; set; } = new List<ConfigServiceBinding>();
         public List<ConfigVolume> Volumes { get; set; } = new List<ConfigVolume>();
         [YamlMember(Alias = "env")]

--- a/src/Microsoft.Tye.Core/DotnetProjectServiceBuilder.cs
+++ b/src/Microsoft.Tye.Core/DotnetProjectServiceBuilder.cs
@@ -31,5 +31,6 @@ namespace Microsoft.Tye
         public string PublishDir { get; set; } = default!;
         public string IntermediateOutputPath { get; set; } = default!;
         public Dictionary<string, string> BuildProperties { get; } = new Dictionary<string, string>();
+        public bool HotReload { get; set; }
     }
 }

--- a/src/Microsoft.Tye.Core/Serialization/ConfigServiceParser.cs
+++ b/src/Microsoft.Tye.Core/Serialization/ConfigServiceParser.cs
@@ -84,6 +84,14 @@ namespace Tye.Serialization
 
                         service.Build = build;
                         break;
+                    case "hotReload":
+                        if (!bool.TryParse(YamlParser.GetScalarValue(key, child.Value), out var hotReload))
+                        {
+                            throw new TyeYamlException(child.Value.Start, CoreStrings.FormatMustBeABoolean(key));
+                        }
+
+                        service.HotReload = hotReload;
+                        break;
                     case "executable":
                         service.Executable = YamlParser.GetScalarValue(key, child.Value);
                         break;

--- a/src/Microsoft.Tye.Hosting/Model/ProjectRunInfo.cs
+++ b/src/Microsoft.Tye.Hosting/Model/ProjectRunInfo.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Tye.Hosting.Model
             ProjectFile = project.ProjectFile;
             Args = project.Args;
             Build = project.Build;
+            HotReload = project.HotReload;
             BuildProperties = project.BuildProperties;
             TargetFramework = project.TargetFramework;
             TargetFrameworkName = project.TargetFrameworkName;
@@ -32,7 +33,8 @@ namespace Microsoft.Tye.Hosting.Model
         public Dictionary<string, string> BuildProperties { get; } = new Dictionary<string, string>();
 
         public string? Args { get; }
-        public bool Build { get; }
+        public bool Build { get; set; }
+        public bool HotReload { get; set; }
         public FileInfo ProjectFile { get; }
         public string TargetFrameworkName { get; set; } = default!;
         public string TargetFrameworkVersion { get; set; } = default!;

--- a/src/Microsoft.Tye.Hosting/ProcessRunner.cs
+++ b/src/Microsoft.Tye.Hosting/ProcessRunner.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Tye.Hosting
                             {
                                 copiedArgs += " --useHttps";
                             }
-                        }                        
+                        }
 
                         _logger.LogInformation("Launching service {ServiceName}: {ExePath} {args}", replica, path, copiedArgs);
 


### PR DESCRIPTION
Based on  #1013 but now optional
I added a 'hotReload' property to project-info (see samples/frontend-backend/tye.yaml where front-end is now using hotReload)
It only starts when combined with --watch. All projects that don't have this property set, still use DotnetFileWatcher.

Although I don't see when you'd prefer DotnetFileWatcher is preferred over dotnet watch, it still is backwards compatible since you must explicitly tell that a project should use dotnet watch.
