### PR TITLE
add dependency map

### DIFF
--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigService.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigService.cs
@@ -46,5 +46,7 @@ namespace Microsoft.Tye.ConfigModel
         public string? Version { get; set; }
         public string? Architecture { get; set; }
         public string? CloneDirectory { get; internal set; }
+        
+        public List<string> DependsOn { get; set; } = new List<string>();
     }
 }

--- a/src/Microsoft.Tye.Core/DockerCompose/DockerComposeParser.cs
+++ b/src/Microsoft.Tye.Core/DockerCompose/DockerComposeParser.cs
@@ -273,6 +273,8 @@ namespace Tye.DockerCompose
                         break;
                     case "tty":
                         break;
+                    case "dependsOn":
+                        break;
                     default:
                         throw new TyeYamlException(child.Key.Start, CoreStrings.FormatUnrecognizedKey(key));
                 }

--- a/src/Microsoft.Tye.Core/DockerCompose/DockerComposeParser.cs
+++ b/src/Microsoft.Tye.Core/DockerCompose/DockerComposeParser.cs
@@ -273,8 +273,6 @@ namespace Tye.DockerCompose
                         break;
                     case "tty":
                         break;
-                    case "dependsOn":
-                        break;
                     default:
                         throw new TyeYamlException(child.Key.Start, CoreStrings.FormatUnrecognizedKey(key));
                 }

--- a/src/Microsoft.Tye.Core/Serialization/ConfigServiceParser.cs
+++ b/src/Microsoft.Tye.Core/Serialization/ConfigServiceParser.cs
@@ -164,6 +164,13 @@ namespace Tye.Serialization
                     case "cloneDirectory":
                         service.CloneDirectory = YamlParser.GetScalarValue(key, child.Value);
                         break;
+                    case "dependsOn":
+                        if (child.Value.NodeType != YamlNodeType.Sequence)
+                        {
+                            throw new TyeYamlException(child.Value.Start, CoreStrings.FormatExpectedYamlSequence(key));
+                        }
+                        HandleDependencies((child.Value as YamlSequenceNode)!, service.DependsOn);
+                        break;
                     default:
                         throw new TyeYamlException(child.Key.Start, CoreStrings.FormatUnrecognizedKey(key));
                 }
@@ -576,6 +583,15 @@ namespace Tye.Serialization
             {
                 var tag = YamlParser.GetScalarValue(child);
                 tags.Add(tag);
+            }
+        }
+        
+        private static void HandleDependencies(YamlSequenceNode yamlSequenceNode, List<string> dependencies)
+        {
+            foreach (var child in yamlSequenceNode!.Children)
+            {
+                var dependsOn = YamlParser.GetScalarValue(child);
+                dependencies.Add(dependsOn);
             }
         }
 

--- a/test/E2ETest/testassets/projects/multirepo/vote/tye.yaml
+++ b/test/E2ETest/testassets/projects/multirepo/vote/tye.yaml
@@ -2,6 +2,8 @@ name: VotingSample
 services:
 - name: vote
   project: vote.csproj
+  dependsOn:
+    - redis
 - name: worker
   include: ../worker/tye.yaml
 - name: redis


### PR DESCRIPTION
This PR aims to solve #1608 & #652

it introduces the dependsOn yaml that looks for services that match the name and ensure the startup order is honoured. 

For Example:

```yaml
name: VotingSample
services:
- name: vote
  project: vote.csproj
  dependsOn:
    - redis
- name: worker
  include: ../worker/tye.yaml
- name: redis
  image: redis
  bindings:
    - port: 6379
      connectionString: ${host}:${port}
```

Should await the Redis server to start before the vote service. 

I will write more E2E tests to validate this and ensure that environment variables are added to services. 